### PR TITLE
SHIRO-568: Fix the calculation for the hash iterations

### DIFF
--- a/crypto/hash/src/main/java/org/apache/shiro/crypto/hash/SimpleHash.java
+++ b/crypto/hash/src/main/java/org/apache/shiro/crypto/hash/SimpleHash.java
@@ -346,7 +346,7 @@ public class SimpleHash extends AbstractHash {
             digest.update(salt);
         }
         byte[] hashed = digest.digest(bytes);
-        int iterations = hashIterations - DEFAULT_ITERATIONS; //already hashed once above
+        int iterations = hashIterations - 1; //already hashed once above
         //iterate remaining number:
         for (int i = 0; i < iterations; i++) {
             digest.reset();


### PR DESCRIPTION
We really need to subtract 1 here, not DEFAULT_ITERATIONS (which could
change, breaking the calculation then)

~~~~
The same change should also applied on the 1.2.x branch.