### PR TITLE
SHIRO-300 Add protected setParts(list) method

### DIFF
--- a/core/src/main/java/org/apache/shiro/authz/permission/WildcardPermission.java
+++ b/core/src/main/java/org/apache/shiro/authz/permission/WildcardPermission.java
@@ -188,6 +188,10 @@ public class WildcardPermission implements Permission, Serializable {
         return this.parts;
     }
 
+    protected void setParts(List<Set<String>> parts) {
+        this.parts = parts;
+    }
+
     /*--------------------------------------------
     |               M E T H O D S               |
     ============================================*/


### PR DESCRIPTION
 WildcardPermission subclasses can create their own parts/subparts list and pass them in with this method.

See https://issues.apache.org/jira/browse/SHIRO-300