### PR TITLE
activeDirectoryRealm.principalSuffix isn't honoured

### DIFF
--- a/core/src/main/java/org/apache/shiro/realm/activedirectory/ActiveDirectoryRealm.java
+++ b/core/src/main/java/org/apache/shiro/realm/activedirectory/ActiveDirectoryRealm.java
@@ -105,7 +105,12 @@ public class ActiveDirectoryRealm extends AbstractLdapRealm {
         // Binds using the username and password provided by the user.
         LdapContext ctx = null;
         try {
-            ctx = ldapContextFactory.getLdapContext(upToken.getUsername(), String.valueOf(upToken.getPassword()));
+            String userPrincipalName = upToken.getUsername();
+            if (this.principalSuffix != null) {
+                userPrincipalName = upToken.getUsername() + this.principalSuffix;
+            }
+            ctx = ldapContextFactory.getLdapContext(
+            userPrincipalName, upToken.getPassword());
         } finally {
             LdapUtils.closeContext(ctx);
         }


### PR DESCRIPTION
While using shiro for auth in my project I noticed that, activeDirectoryRealm.principalSuffix is not honoured for authentication, however, for getRoleNamesForUser it does append the same.

Looking at the tcpdump, it appears activeDirectoryRealm.principalSuffix isn't honoured. As a result, the bind request searches for user_name, rather than user_name@company.com. Also note that if I try to login as username "user_name@company.com", I do authenticate as I'm found in the directory server