### PR TITLE
WIP: Ability to set a property value with an enum in shiro.ini file

### DIFF
--- a/config/ogdl/src/main/java/org/apache/shiro/config/ReflectionBuilder.java
+++ b/config/ogdl/src/main/java/org/apache/shiro/config/ReflectionBuilder.java
@@ -422,6 +422,17 @@ public class ReflectionBuilder {
             throw new ConfigurationException(msg, e);
         }
     }
+    //@since 1.3 : be able to set an enum value for an object property
+    protected Enum toEnum(Object object, String propertyName, String sValue) {
+        try {
+            PropertyDescriptor descriptor = PropertyUtils.getPropertyDescriptor(object, propertyName);
+            Class<? extends Enum> propertyClazz = (Class<? extends Enum>) descriptor.getPropertyType();
+            return Enum.valueOf(propertyClazz, sValue);
+        } catch (Exception e) {
+            String msg = "Unable to cast property [" + propertyName + "] into an enum for value " + sValue;
+            throw new ConfigurationException(msg, e);
+        }
+    }
 
     protected Set<?> toSet(String sValue) {
         String[] tokens = StringUtils.split(sValue);
@@ -698,6 +709,8 @@ public class ReflectionBuilder {
         } else if (isIndexedPropertyAssignment(propertyName)) {
             String checked = checkForNullOrEmptyLiteral(stringValue);
             value = resolveValue(checked);
+        } else if (isTypedProperty(object, propertyName, Enum.class)) {
+            value = toEnum(object, propertyName, stringValue);
         } else if (isTypedProperty(object, propertyName, Set.class)) {
             value = toSet(stringValue);
         } else if (isTypedProperty(object, propertyName, Map.class)) {

--- a/config/ogdl/src/test/groovy/org/apache/shiro/config/ReflectionBuilderTest.groovy
+++ b/config/ogdl/src/test/groovy/org/apache/shiro/config/ReflectionBuilderTest.groovy
@@ -524,4 +524,44 @@ class ReflectionBuilderTest {
         assertEquals(5, bean.getIntProp());
         assertEquals("someString", bean.getStringProp());
     }
+
+    @Test
+    public void testParsingEnum() {
+
+        String objectName = "myObject";
+        String objectProperty = objectName + ".enumProperty";
+        String listProperty = objectName + ".enumList";
+        String mapProperty = objectName + ".enumMap";
+
+        ReflectionBuilder reflectionBuilder = new ReflectionBuilder();
+        // Order matters
+        Map<String, String> lines = new LinkedHashMap<String, String>();
+        lines.put(objectName, SimpleEnumPropertyObject.class.getName());
+
+        lines.put(objectProperty, SimpleEnum.VALUE2.toString());
+        lines.put(listProperty, SimpleEnum.VALUE2.toString() +", " + SimpleEnum.VALUE1.toString() );
+        lines.put(mapProperty, "two:"+ SimpleEnum.VALUE2.toString() +", one:" + SimpleEnum.VALUE1.toString() );
+
+        Map<String, Object> results = reflectionBuilder.buildObjects(lines);
+
+        // check that buildObjects returns the expected object
+        Object obj = results.get(objectName);
+        assertTrue(obj instanceof SimpleEnumPropertyObject);
+        SimpleEnumPropertyObject myObject = (SimpleEnumPropertyObject)obj;
+        assertEquals(SimpleEnum.VALUE2, myObject.getEnumProperty());
+
+        // now getBean should do the same thing
+        obj = reflectionBuilder.getBean(objectName);
+        assertTrue(obj instanceof SimpleEnumPropertyObject);
+        myObject = (SimpleEnumPropertyObject)obj;
+        assertEquals(SimpleEnum.VALUE2, myObject.getEnumProperty());
+
+        // TODO: FIX these
+        def expectedResultList = [SimpleEnum.VALUE2, SimpleEnum.VALUE1];
+        assertEquals(expectedResultList, myObject.getEnumList());
+
+        def expectedResultMap = [two: SimpleEnum.VALUE2, one: SimpleEnum.VALUE1]
+        assertEquals(expectedResultMap, myObject.getEnumMap());
+
+    }
 }

--- a/config/ogdl/src/test/groovy/org/apache/shiro/config/SimpleEnum.groovy
+++ b/config/ogdl/src/test/groovy/org/apache/shiro/config/SimpleEnum.groovy
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.shiro.config
+
+/**
+ * Simple enumeration for tests.
+ *
+ * @since 1.3.0
+ */
+enum SimpleEnum {
+    VALUE1, VALUE2
+}

--- a/config/ogdl/src/test/groovy/org/apache/shiro/config/SimpleEnumPropertyObject.groovy
+++ b/config/ogdl/src/test/groovy/org/apache/shiro/config/SimpleEnumPropertyObject.groovy
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.shiro.config
+
+/**
+ * Simple object with enum property for tests.
+ *
+ * @since 1.3.0
+ */
+class SimpleEnumPropertyObject {
+
+    SimpleEnum enumProperty;
+
+    List<SimpleEnum> enumList;
+
+    Map<String,SimpleEnum> enumMap = new LinkedHashMap<String,SimpleEnum>();
+}


### PR DESCRIPTION
SHIRO-425 (applied patch to master)
This enum support could be limited to property only, but that might cause confusion.

Currently supported via this patch:

``` ini
[main]
myObject = com.foo.bar.Type
myObject.enumProperty = ENUM_VALUE1
```

This is really cool, but as a user I would also expect the following to work:

``` ini
[main]
myObject = com.foo.bar.Type
myObject.enumListProperty = ENUM_VALUE1, ENUM_VALUE2
```

``` ini
[main]
myObject = com.foo.bar.Type
myObject.enumMapProperty = one:ENUM_VALUE1, two:ENUM_VALUE2
```

Granted the Map example might be a bit contrived, but less so for the list.

I've added a test for this.

Thoughts ?
