### PR TITLE
SHIRO-577 Fixes bug allow enabling of SessionValidationScheduler when set via setSessionValidationScheduler

### DIFF
--- a/core/src/main/java/org/apache/shiro/session/mgt/AbstractValidatingSessionManager.java
+++ b/core/src/main/java/org/apache/shiro/session/mgt/AbstractValidatingSessionManager.java
@@ -225,6 +225,10 @@ public abstract class AbstractValidatingSessionManager extends AbstractNativeSes
         if (scheduler == null) {
             scheduler = createSessionValidationScheduler();
             setSessionValidationScheduler(scheduler);
+        }
+        // it is possible that that a scheduler was already created and set via 'setSessionValidationScheduler()'
+        // but would not have been enabled/started yet
+        if (!scheduler.isEnabled()) {
             if (log.isInfoEnabled()) {
                 log.info("Enabling session validation scheduler...");
             }

--- a/core/src/test/java/org/apache/shiro/session/mgt/DefaultSessionManagerTest.java
+++ b/core/src/test/java/org/apache/shiro/session/mgt/DefaultSessionManagerTest.java
@@ -192,6 +192,31 @@ public class DefaultSessionManagerTest {
         verify(sessionDAO); //verify that the delete call was actually made on the DAO
     }
 
+    /**
+     * Tests a bug introduced by SHIRO-443, where a custom sessionValidationScheduler would not be started.
+     */
+    @Test
+    public void testEnablingOfCustomSessionValidationScheduler() {
+
+        // using the default impl of sessionValidationScheduler, as the but effects any scheduler we set directly via
+        // sessionManager.setSessionValidationScheduler(), commonly used in INI configuration.
+        ExecutorServiceSessionValidationScheduler sessionValidationScheduler = new ExecutorServiceSessionValidationScheduler();
+        DefaultSessionManager sessionManager = new DefaultSessionManager();
+        sessionManager.setSessionValidationScheduler(sessionValidationScheduler);
+
+        // starting a session will trigger the starting of the validator
+        try {
+            Session session = sessionManager.start(null);
+
+            // now sessionValidationScheduler should be enabled
+            assertTrue("sessionValidationScheduler was not enabled", sessionValidationScheduler.isEnabled());
+        }
+        finally {
+            // cleanup after test
+            sessionManager.destroy();
+        }
+    }
+
     public static <T extends Session> T eqSessionTimeout(long timeout) {
         EasyMock.reportMatcher(new SessionTimeoutMatcher(timeout));
         return null;


### PR DESCRIPTION
If a SessionValidationScheduler was set via sessionManager.setSessionValidationScheduler, instead of using the
default creation of the object in enableSessionValidation, the SessionValidationScheduler would not be enabled.