### PR TITLE
SHIRO-586 - Can't Search For Groups In Active Directory Without A System User

### DIFF
--- a/core/src/main/java/org/apache/shiro/realm/activedirectory/ActiveDirectoryRealm.java
+++ b/core/src/main/java/org/apache/shiro/realm/activedirectory/ActiveDirectoryRealm.java
@@ -155,7 +155,7 @@ public class ActiveDirectoryRealm extends AbstractLdapRealm {
         return new SimpleAuthorizationInfo(roleNames);
     }
 
-    private Set<String> getRoleNamesForUser(String username, LdapContext ldapContext) throws NamingException {
+    protected Set<String> getRoleNamesForUser(String username, LdapContext ldapContext) throws NamingException {
         Set<String> roleNames;
         roleNames = new LinkedHashSet<String>();
 


### PR DESCRIPTION
Change getRoleNamesForUser from private to protected so that it can be used in sub-classes.
This will enable implementing a custom Realm (that sub-classes ActiveDirectoryRealm) able to access groups/roles without needing a system user.