### PR TITLE
SHIRO-576 Commons-beanutils dependency is not security compliant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -726,7 +726,7 @@
             <dependency>
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
-                <version>1.8.3</version>
+                <version>1.9.3</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-logging</groupId>


### PR DESCRIPTION
Updated dependency beanutils to version 1.9.3 in order to get rid of CVE-2014-0114
https://issues.apache.org/jira/browse/SHIRO-576