### PR TITLE
When using more than 1 realm for authentication ModularRealmAuthenticator would log a stack trace each time a user enters a wrong password. Turned down the logging level for this to happen from WARN to TRACE.

### DIFF
--- a/core/src/main/java/org/apache/shiro/authc/pam/ModularRealmAuthenticator.java
+++ b/core/src/main/java/org/apache/shiro/authc/pam/ModularRealmAuthenticator.java
@@ -219,9 +219,9 @@ public class ModularRealmAuthenticator extends AbstractAuthenticator {
                     info = realm.getAuthenticationInfo(token);
                 } catch (Throwable throwable) {
                     t = throwable;
-                    if (log.isWarnEnabled()) {
+                    if (log.isTraceEnabled()) {
                         String msg = "Realm [" + realm + "] threw an exception during a multi-realm authentication attempt:";
-                        log.warn(msg, t);
+                        log.trace(msg, t);
                     }
                 }
 


### PR DESCRIPTION
When using more than 1 realm for authentication ModularRealmAuthenticator would log a stack trace each time a user enters a wrong password. Turned down the logging level for this to happen from WARN to TRACE.