### PR TITLE
Hazelcast version bumped-up to 3.7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
              modules' OSGi metadata: -->
         <ehcache.version>2.5.3</ehcache.version>
         <!-- Don't change this version without also changing the shiro-hazelcast and shiro-features OSGi metadata: -->
-        <hazelcast.version>2.4.1</hazelcast.version>
+        <hazelcast.version>3.7.2</hazelcast.version>
         <hsqldb.version>1.8.0.7</hsqldb.version>
         <jdk.version>1.5</jdk.version>
         <jetty.version>6.1.26</jetty.version>
@@ -803,7 +803,7 @@
             <dependency>
                 <groupId>com.hazelcast</groupId>
                 <artifactId>hazelcast</artifactId>
-                <version>2.4.1</version>
+                <version>3.7.2</version>
             </dependency>
             <dependency>
                 <!-- Used for sample applications only - not required for the framework: -->

--- a/support/features/pom.xml
+++ b/support/features/pom.xml
@@ -26,6 +26,7 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
+
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shiro-features</artifactId>
     <name>Apache Shiro :: Support :: Karaf Features</name>
@@ -34,7 +35,7 @@
     <properties>
         <aspectj.bundle.version>1.6.16_1</aspectj.bundle.version>
         <ehcache.bundle.version>2.5.3_1</ehcache.bundle.version>
-        <hazelcast.bundle.version>2.4.1_1</hazelcast.bundle.version>
+        <hazelcast.bundle.version>3.7.2_1</hazelcast.bundle.version>
         <quartz.bundle.version>1.6.1_1</quartz.bundle.version>
         <!-- Not a Shiro dependency - used for quartz bundle resolution only (see features.xml): -->
         <commons.collections.version>3.2.1</commons.collections.version>

--- a/support/hazelcast/pom.xml
+++ b/support/hazelcast/pom.xml
@@ -32,7 +32,7 @@
     <packaging>bundle</packaging>
 
     <properties>
-        <hazelcast.osgi.importRange>[2.4, 3)</hazelcast.osgi.importRange>
+        <hazelcast.osgi.importRange>[2.4, 4)</hazelcast.osgi.importRange>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
 Reasoning: 2.4 is a very old release and it's no longer supported.