### PR TITLE
SslFilter with HTTP Strict Transport Security (HSTS)

### DIFF
--- a/web/src/main/java/org/apache/shiro/web/filter/authz/SslFilter.java
+++ b/web/src/main/java/org/apache/shiro/web/filter/authz/SslFilter.java
@@ -112,11 +112,11 @@ public class SslFilter extends PortFilter {
      */
     @Override
     protected void postHandle(ServletRequest request, ServletResponse response)  {
-        if (hsts.enabled) {
+        if (hsts.isEnabled()) {
             StringBuilder directives = new StringBuilder(64)
                     .append("max-age=").append(hsts.getMaxAge());
             
-            if (hsts.includeSubDomains) {
+            if (hsts.isIncludeSubDomains()) {
                 directives.append("; includeSubDomains");
             }
             
@@ -130,17 +130,18 @@ public class SslFilter extends PortFilter {
      */
     public class HSTS {
         
+        public static final String HTTP_HEADER = "Strict-Transport-Security";
+        
         public static final boolean DEFAULT_ENABLED = false;
         public static final int DEFAULT_MAX_AGE = 31536000; // approx. one year in seconds
         public static final boolean DEFAULT_INCLUDE_SUB_DOMAINS = false;
-        
-        public static final String HTTP_HEADER = "Strict-Transport-Security";
         
         private boolean enabled;
         private int maxAge;
         private boolean includeSubDomains;
         
         public HSTS() {
+            this.enabled = DEFAULT_ENABLED;
             this.maxAge = DEFAULT_MAX_AGE;
             this.includeSubDomains = DEFAULT_INCLUDE_SUB_DOMAINS;
         }

--- a/web/src/main/java/org/apache/shiro/web/filter/authz/SslFilter.java
+++ b/web/src/main/java/org/apache/shiro/web/filter/authz/SslFilter.java
@@ -20,6 +20,7 @@ package org.apache.shiro.web.filter.authz;
 
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * Filter which requires a request to be over SSL.  Access is allowed if the request is received on the configured
@@ -30,21 +31,46 @@ import javax.servlet.ServletResponse;
  * The {@link #getPort() port} property defaults to {@code 443} and also additionally guarantees that the
  * request scheme is always 'https' (except for port 80, which retains the 'http' scheme).
  * <p/>
- * Example config:
+ * In addition the filter allows enabling HTTP Strict Transport Security (HSTS).
+ * This feature is opt-in and disabled by default. If enabled HSTS
+ * will prevent <b>any</b> communications from being sent over HTTP to the 
+ * specified domain and will instead send all communications over HTTPS.
+ * </p>
+ * <b>Warning:</b> Use this setting only if you plan to enable SSL on every path.
+ * </p>
+ * Example configs:
  * <pre>
  * [urls]
  * /secure/path/** = ssl
  * </pre>
- *
+ * with HSTS enabled
+ * <pre>
+ * [main]
+ * ssl.hsts.enabled = true
+ * [urls]
+ * /** = ssl
+ * </pre>
  * @since 1.0
+ * @see <a href="https://tools.ietf.org/html/rfc6797">HTTP Strict Transport Security (HSTS)</a>
  */
 public class SslFilter extends PortFilter {
 
     public static final int DEFAULT_HTTPS_PORT = 443;
     public static final String HTTPS_SCHEME = "https";
+    
+    private HSTS hsts;
 
     public SslFilter() {
         setPort(DEFAULT_HTTPS_PORT);
+        this.hsts = new HSTS();
+    }
+
+    public HSTS getHsts() {
+        return hsts;
+    }
+
+    public void setHsts(HSTS hsts) {
+        this.hsts = hsts;
     }
 
     @Override
@@ -72,5 +98,59 @@ public class SslFilter extends PortFilter {
     @Override
     protected boolean isAccessAllowed(ServletRequest request, ServletResponse response, Object mappedValue) throws Exception {
         return super.isAccessAllowed(request, response, mappedValue) && request.isSecure();
+    }
+
+    @Override
+    protected void postHandle(ServletRequest request, ServletResponse response) throws Exception {
+        if (hsts.enabled) {
+            StringBuilder directives = new StringBuilder(64);
+            directives.append("max-age=").append(hsts.getMaxAge());
+            if (hsts.includeSubDomains) {
+                directives.append("; includeSubDomains");
+            }
+            HttpServletResponse resp = (HttpServletResponse) response;
+            resp.addHeader("Strict-Transport-Security", directives.toString());
+        }
+    }
+    
+    public class HSTS {
+        
+        static final boolean DEFAULT_ENABLED = false;
+        public static final int DEFAULT_EXPIRE_TIME = 31536000; // approx. one year in seconds
+        public static final boolean DEFAULT_INCLUDE_SUB_DOMAINS = false;
+        
+        private boolean enabled;
+        private int maxAge;
+        private boolean includeSubDomains;
+        
+        public HSTS() {
+            this.maxAge = DEFAULT_EXPIRE_TIME;
+            this.includeSubDomains = DEFAULT_INCLUDE_SUB_DOMAINS;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public int getMaxAge() {
+            return maxAge;
+        }
+
+        public void setMaxAge(int maxAge) {
+            this.maxAge = maxAge;
+        }
+
+        public boolean isIncludeSubDomains() {
+            return includeSubDomains;
+        }
+
+        public void setIncludeSubDomains(boolean includeSubDomains) {
+            this.includeSubDomains = includeSubDomains;
+        }
+        
     }
 }

--- a/web/src/test/java/org/apache/shiro/web/filter/authz/SslFilterTest.java
+++ b/web/src/test/java/org/apache/shiro/web/filter/authz/SslFilterTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.web.filter.authz;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.Test;
+
+import static org.apache.shiro.web.filter.authz.SslFilter.HSTS.*;
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+public class SslFilterTest {
+
+    @Test
+    public void testDisabledByDefault() {
+        HttpServletRequest request = createNiceMock(HttpServletRequest.class);
+        HttpServletResponse response = createNiceMock(HttpServletResponse.class);
+
+        SslFilter sslFilter = new SslFilter();
+
+        sslFilter.postHandle(request, response);
+        assertNull(response.getHeader(HTTP_HEADER));
+    }
+
+    @Test
+    public void testDefaultValues() {
+        HttpServletRequest request = createNiceMock(HttpServletRequest.class);
+        HttpServletResponse response = createNiceMock(HttpServletResponse.class);
+
+//        String expected = new StringBuilder()
+//                .append(HTTP_HEADER)
+//                .append(": ")
+//                .append("max-age=")
+//                .append(DEFAULT_MAX_AGE)
+//                .toString();
+//        expect(response.addHeader(expected, expected))
+//                .andReturn(expected)
+//                .anyTimes();
+        replay(response);
+//        
+        SslFilter sslFilter = new SslFilter();
+        sslFilter.getHsts().setEnabled(true);
+
+        sslFilter.postHandle(request, response);
+
+        //assertEquals(expected, response.getHeader(HTTP_HEADER));
+    }
+
+}


### PR DESCRIPTION
Hi Brian,

we talked on the mailing list. For anyone not involved here is the summary.

HTTP Strict Transport Security (HSTS) would be a nice addition for all the SSL only sites out there. I think in recent years more and more pages have gone full SSL, with good reasons to do so. It is a bit problematic with SslFilter since this one is path based. If you go HSTS then everything on the site uses https. This might break thinks if you have a path with ssl and one without. You can do that with shiro but not with HSTS.

Some words on the implementation, I am not sure on some things.

I have never used EasyMock before. The test cases in SslFilterTest run fine, but maybe I did it very overcomplicated.

Is `postHandle` invoked even if `isAccessAllowed` returns false? The user agent has to ignore the HTTP header if it is send over HTTP, but I would prefer to send it only over HTTPS. So `isAccessAllowed` needs to return true. I could move the logic to isAccessAllowed, but it looked like the wrong place.
