### PR TITLE
SHIRO-618 - Autoconfiguration for Realm and ShiroFilterChainDefinition

### DIFF
--- a/support/spring-boot/spring-boot-web-starter/src/main/java/org/apache/shiro/spring/config/web/autoconfigure/ShiroNoRealmConfiguredFailureAnalyzer.java
+++ b/support/spring-boot/spring-boot-web-starter/src/main/java/org/apache/shiro/spring/config/web/autoconfigure/ShiroNoRealmConfiguredFailureAnalyzer.java
@@ -1,0 +1,14 @@
+package org.apache.shiro.spring.config.web.autoconfigure;
+
+import org.apache.shiro.spring.config.web.autoconfigure.exception.NoRealmBeanConfiguredException;
+import org.springframework.boot.diagnostics.AbstractFailureAnalyzer;
+import org.springframework.boot.diagnostics.FailureAnalysis;
+
+public class ShiroNoRealmConfiguredFailureAnalyzer extends AbstractFailureAnalyzer<NoRealmBeanConfiguredException> {
+ 
+ 	@Override
+ 	protected FailureAnalysis analyze(Throwable rootFailure, NoRealmBeanConfiguredException cause) {
+ 		return new FailureAnalysis( "No bean of type 'org.apache.shiro.realm.Realm' found.", "Please create bean of type realm or add a shiro.ini in the root classpath (src/main/resources/shiro.ini) or in the META-INF folder (src/main/resources/META-INF/shiro.ini) .", cause);
+ 	}
+ 
+ }

--- a/support/spring-boot/spring-boot-web-starter/src/main/java/org/apache/shiro/spring/config/web/autoconfigure/ShiroWebAutoConfiguration.java
+++ b/support/spring-boot/spring-boot-web-starter/src/main/java/org/apache/shiro/spring/config/web/autoconfigure/ShiroWebAutoConfiguration.java
@@ -18,24 +18,30 @@
  */
 package org.apache.shiro.spring.config.web.autoconfigure;
 
+import java.util.List;
+
 import org.apache.shiro.authc.Authenticator;
 import org.apache.shiro.authc.pam.AuthenticationStrategy;
 import org.apache.shiro.authz.Authorizer;
-import org.apache.shiro.mgt.*;
+import org.apache.shiro.config.Ini;
+import org.apache.shiro.mgt.RememberMeManager;
+import org.apache.shiro.mgt.SessionStorageEvaluator;
+import org.apache.shiro.mgt.SessionsSecurityManager;
+import org.apache.shiro.mgt.SubjectDAO;
+import org.apache.shiro.mgt.SubjectFactory;
 import org.apache.shiro.realm.Realm;
+import org.apache.shiro.realm.text.IniRealm;
 import org.apache.shiro.session.mgt.SessionFactory;
 import org.apache.shiro.session.mgt.SessionManager;
 import org.apache.shiro.session.mgt.eis.SessionDAO;
+import org.apache.shiro.spring.config.web.autoconfigure.exception.NoRealmBeanConfiguredException;
 import org.apache.shiro.spring.web.config.AbstractShiroWebConfiguration;
 import org.apache.shiro.web.servlet.Cookie;
-import org.springframework.boot.autoconfigure.AutoConfigureOrder;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnResource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
-
-import java.util.List;
 
 /**
  * @since 1.4.0
@@ -133,6 +139,28 @@ public class ShiroWebAutoConfiguration extends AbstractShiroWebConfiguration {
     @Override
     protected SessionsSecurityManager securityManager(List<Realm> realms) {
         return super.securityManager(realms);
+    }
+    
+    @Bean
+    @ConditionalOnResource(resources = "classpath:shiro.ini")
+    protected Realm iniClasspathRealm() {
+        Ini ini = Ini.fromResourcePath("classpath:shiro.ini");
+        IniRealm iniRealm = new IniRealm( ini );
+        return iniRealm;
+    }
+    
+    @Bean
+    @ConditionalOnResource(resources = "classpath:META-INF/shiro.ini")
+    protected Realm iniMetaInfClasspathRealm() {
+        Ini ini = Ini.fromResourcePath("classpath:META-INF/shiro.ini");
+        IniRealm iniRealm = new IniRealm( ini );
+        return iniRealm;
+    }
+    
+    @Bean
+    @ConditionalOnMissingBean(Realm.class)
+    protected Realm missingRealm() {
+        throw new NoRealmBeanConfiguredException();
     }
 
 }

--- a/support/spring-boot/spring-boot-web-starter/src/main/java/org/apache/shiro/spring/config/web/autoconfigure/exception/NoRealmBeanConfiguredException.java
+++ b/support/spring-boot/spring-boot-web-starter/src/main/java/org/apache/shiro/spring/config/web/autoconfigure/exception/NoRealmBeanConfiguredException.java
@@ -1,0 +1,9 @@
+package org.apache.shiro.spring.config.web.autoconfigure.exception;
+
+/**
+ * This exception should be thrown if not bean of type {@link Realm} found.
+ *
+ */
+public class NoRealmBeanConfiguredException extends RuntimeException {
+
+}

--- a/support/spring-boot/spring-boot-web-starter/src/main/resources/META-INF/spring.factories
+++ b/support/spring-boot/spring-boot-web-starter/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration = org.apache.shiro.spring.config.web.autoconfigure.ShiroBeanAutoConfiguration,org.apache.shiro.spring.config.web.autoconfigure.ShiroWebAutoConfiguration,org.apache.shiro.spring.config.web.autoconfigure.ShiroWebFilterConfiguration,org.apache.shiro.spring.config.web.autoconfigure.ShiroAnnotationProcessorAutoConfiguration
+
+org.springframework.boot.diagnostics.FailureAnalyzer=org.apache.shiro.spring.config.web.autoconfigure.ShiroNoRealmConfiguredFailureAnalyzer


### PR DESCRIPTION
* automatic realm configuration for shiro.ini / META-INF/shiro.ini
* providing a detailed exception with the help of Spring Boots AbstractFailureAnalyzer if no realm bean is configured
