### PR TITLE
about Beginner’s Webapp Tutorial: a step-by-step tutorial to enable Shiro in a web application

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -21,6 +21,129 @@ combined with Jira's auto-generated release notes during a release for the
 total set.
 
 ###########################################################
+# 2.0 alpha 0
+###########################################################
+
+The 2.0 alpha 0 release's design goal is to introduce a much cleaner, more intuitive, more configurable API that is
+even easier to understand and use than previous Shiro versions.
+
+The design changes however introduce enough change such that there will be a decent amount of deprecation of old
+concepts and implementations; the releases before 2.0.0 final will retain all of these 'legacy' concepts and
+implementations to provide a smoother upgrade path for those trying alpha and beta releases.
+
+2.0.0 final however will completely remove all deprecated interfaces, classes and methods to ensure a clean
+codebase for the many years to come.
+
+Design Changes
+--------------------------------
+
+- All of Shiro's SecurityManager implementations now require a CacheManager - it cannot be null.  Caching is still
+  disabled by default however; the SecurityManager implementations just default to an
+  org.apache.shiro.cache.DisabledCacheManager instance.  This reflects the Null Object design pattern, helping
+  reducing cyclomatic complexity (and therefore the potential for bugs) in Shiro.
+
+- org.apache.shiro.subject.PrincipalCollection has been deprecated and will be removed in 2.0 final.  This represents
+  a big change, but for an extremely strong reason:
+
+  Almost all Shiro end-users expect to be able to query a Subject's PrincipalCollection for identifying attributes,
+  like a username, or first name, etc.  This is extraordinarily difficult with the PrincipalCollection API, which
+  only allows users to acquire identity attributes _by type_.  If you had more than one attribute of the same
+  type (e.g. a String username and a String surname), the PrincipalCollection is effectively useless, and you had to
+  come up with all sorts of workarounds (like creating 'wrapper' objects) to obtain the data you needed.  Additionally
+  these workarounds were not usable by any tools or frameworks that used reflection to lookup information.
+
+  This was a huge problem, almost crippling in some cases, and so PrincipalCollection has been deprecated and
+  replaced by a very simple 'attributes' map, of type Map<String,Object>.  This allows much cleaner code, like:
+
+  subject.getAttributes().get("username");
+
+  or, even simpler for Groovy or JSTL:
+
+  subject.attributes[username]
+
+  This change affords a huge number of simplifications/conveniences for the Shriro user community, dev team, and
+  bean-compatible tools and frameworks.
+
+- org.apache.shiro.authc.AuthenticationInfo (used widely by Realm implementations) has been deprecated and will be
+  replaced by a brand new org.apache.shiro.account.Account interface.  This was done for three reasons:
+
+  1. Account supports a getId() method, which allows explicit support for a data-store-unique account identifier.
+     AuthenticationInfo did not have this, and id acquisition was implicit - not good for such a core Shiro concept.
+
+  2. 'Account' is an inherently more intuitive name.  The < 2.0 'AuthenticationInfo' interface name actually always
+     represented an Account, and the name 'AuthenticationInfo' is abstract and fairly unintuitive.  Now it is more
+     obvious/explicity.
+
+  3. Shiro's old PrincipalCollection concept is being removed.  Account instead represents principals with a
+     new name, called 'attributes' as a simple Map<String,Object> collections, as described above.
+
+  org.apache.shiro.authc.AuthenticationInfo is currently deprecated, but will be removed entirely when 2.0 final is
+  released.
+
+- The previously (very) complicated SecurityManager implementation hierarchy has been deprecated entirely:
+
+  CachingSecurityManager < RealmSecurityManager < AuthenticatingSecurityManager < AuthorizingSecurityManager
+      < SessionsSecurityManager < DefaultSecurityManager < DefaultWebSecurityManager
+
+  An interim replacement, org.apache.shiro.mgt.ApplicationSecurityManager is the only SecurityManager implementation.
+  All customization for this implementation can be done by customizing or plugging in its internal components.  This is
+  now possible because the implementation much more heavily favors a "delegation over inheritance" best practice.
+  This approach will allow much greater resilience to change over time and help keep Shiro's core SecurityManager
+  codebase highly stable.
+
+  Right before the 2.0 final release, ApplicationSecurityManager might be renamed to DefaultSecurityManager to adhere
+  to all other existing default implementation naming conventions.  This just cannot be done prior to a 2.0 final
+  release because it would be a backwards-incompatible change.
+
+- For multi-realm authentication, the org.apache.shiro.authc.pam package and all of its internal
+  org.apache.shiro.authc.pam.AuthenticationStrategy implementations have been deprecated in favor of the new
+  org.apache.shiro.authc.strategy package.
+
+  The new org.apache.shiro.authc.strategy.AuthenticationStrategy interface is much simpler - it is a single method that
+  can perform all multi-realm interaction logic without compromise.
+
+  The legacy org.apache.shiro.authc.pam.AuthenticationStrategy API and implementations suffered from an overly complex
+  pre/before/after/post implementation requirement, and in some cases, entirely prevented some Strategy behavior from
+  being implemented successfully.
+
+  For example the org.apache.shiro.authc.pam.FirstSuccessfulStrategy did not
+  short-circuit realm iteration (desired by most Shiro users) and the existing Strategy API provided no way to 'tell'
+  the calling Authorizer how to stop iteration when things were successful.  The new Strategy API has no such problems,
+  and is more holistic, allowing implementors exact control over the login attempt.
+
+  Finally, the *Strategy implementations have been renamed to include the word 'Realm' in the name to more explicitly
+  self-document what is occurring.
+
+  For example, the class name 'FirstRealmSuccessfulStrategy' (in 2.0) is more intuitive than
+  'FirstSuccessfulStrategy' in pre 2.0 (first *what* is successful?).  The 2.0 implementations naming scheme makes it
+  very clear what is occurring.
+
+- org.apache.shiro.authc.AuthenticationInfo (used widely by Realms) has been deprecated in favor of a
+
+Deprecations (will be removed immediately before 2.0 final)
+-----------------------------------------------------------
+
+- org.apache.shiro.cache.Cache methods clear(), size() and keys() have been deprecated and will be removed before the
+  2.0 final release.  These methods were never called by Shiro's components and caused an unnecessary implementation
+  burden.
+
+- org.apache.shiro.authc.credential.CredentialsMatcher doCredentialsMatch(AuthenticationToken, AuthenticationInfo)
+  has been deprecated in favor of the new method (in the same interface):
+  credentialsMatch(AuthenticationToken, Account) to reflect the new Account concept (discussed in 'Design Changes'
+  above).
+
+- org.apache.shiro.authc.credential.HashedCredentialsMatcher and all of its children implementations
+  (Md5CredentialsMatcher, Sha256CredentialsMatcher, etc) have been deprecated and will be removed in 2.0 final.  The
+  org.apache.shiro.authc.credential.PasswordMatcher and org.apache.shiro.authc.credential.PasswordService
+  introduced in 1.2 perform all of these operations and more.
+
+New Features / Implementations
+--------------------------------
+- org.apache.shiro.cache.DisabledCacheManager returns no-op implementations for all caching operations.  Mostly usable
+  for the Null Object design pattern.
+
+
+###########################################################
 # 1.2.0
 ###########################################################
 

--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -59,7 +59,7 @@ Design Changes
 
   or, even simpler for Groovy or JSTL:
 
-  subject.attributes[username]
+  subject.attributes['username']
 
   This change affords a huge number of simplifications/conveniences for the Shriro user community, dev team, and
   bean-compatible tools and frameworks.
@@ -72,7 +72,7 @@ Design Changes
 
   2. 'Account' is an inherently more intuitive name.  The < 2.0 'AuthenticationInfo' interface name actually always
      represented an Account, and the name 'AuthenticationInfo' is abstract and fairly unintuitive.  Now it is more
-     obvious/explicity.
+     obvious/explicit.
 
   3. Shiro's old PrincipalCollection concept is being removed.  Account instead represents principals with a
      new name, called 'attributes' as a simple Map<String,Object> collections, as described above.

--- a/cache/src/main/java/org/apache/shiro/cache/Cache.java
+++ b/cache/src/main/java/org/apache/shiro/cache/Cache.java
@@ -48,7 +48,7 @@ public interface Cache<K, V> {
      *
      * @param key   the key used to identify the object being stored.
      * @param value the value to be stored in the cache.
-     * @return the previous value associated with the given {@code key} or {@code null} if there was previous value
+     * @return the previous value associated with the given {@code key} or {@code null} if there was no previous value
      * @throws CacheException if there is a problem accessing the underlying cache system
      */
     public V put(K key, V value) throws CacheException;
@@ -57,7 +57,7 @@ public interface Cache<K, V> {
      * Remove the cache entry corresponding to the specified key.
      *
      * @param key the key of the entry to be removed.
-     * @return the previous value associated with the given {@code key} or {@code null} if there was previous value
+     * @return the previous value associated with the given {@code key} or {@code null} if there was no previous value
      * @throws CacheException if there is a problem accessing the underlying cache system
      */
     public V remove(K key) throws CacheException;
@@ -66,21 +66,27 @@ public interface Cache<K, V> {
      * Clear all entries from the cache.
      *
      * @throws CacheException if there is a problem accessing the underlying cache system
+     * @deprecated since 2.0.  Shiro's implementations never called this method - it is extraneous and causes unnecessary implementation requirements on Cache implementors.
      */
+    @Deprecated
     public void clear() throws CacheException;
 
     /**
      * Returns the number of entries in the cache.
      *
      * @return the number of entries in the cache.
+     * @deprecated since 2.0.  Shiro's implementations never called this method - it is extraneous and causes unnecessary implementation requirements on Cache implementors.
      */
+    @Deprecated
     public int size();
 
     /**
      * Returns a view of all the keys for entries contained in this cache.
      *
      * @return a view of all the keys for entries contained in this cache.
+     * @deprecated since 2.0.  Shiro's implementations never called this method - it is extraneous and causes unnecessary implementation requirements on Cache implementors.
      */
+    @Deprecated
     public Set<K> keys();
 
     /**

--- a/cache/src/main/java/org/apache/shiro/cache/CacheManagerAware.java
+++ b/cache/src/main/java/org/apache/shiro/cache/CacheManagerAware.java
@@ -23,7 +23,7 @@ package org.apache.shiro.cache;
  * one is available.
  *
  * <p>This is used so internal security components that use a CacheManager can be injected with it instead of having
- * to create one on their own.
+ * to create one on their own.</p>
  *
  * @since 0.9
  */

--- a/cache/src/main/java/org/apache/shiro/cache/DisabledCacheManager.java
+++ b/cache/src/main/java/org/apache/shiro/cache/DisabledCacheManager.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.cache;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * A {@code CacheManager} implementation that does not perform any caching at all.  While at first glance this concept
+ * might sound odd, it reflects the <a href="http://en.wikipedia.org/wiki/Null_Object_pattern">Null Object Design
+ * Pattern</a>: other parts of Shiro or users' code do not need to perform null checks when interacting with Cache or
+ * CacheManager instances, reducing code verbosity, enhancing readability, and reducing probability for certain bugs.
+ *
+ * @since 2.0
+ */
+public class DisabledCacheManager implements CacheManager {
+
+    public static final DisabledCacheManager INSTANCE = new DisabledCacheManager();
+
+    private static final Cache DISABLED_CACHE = new DisabledCache();
+
+    @SuppressWarnings("unchecked")
+    public <K, V> Cache<K, V> getCache(String name) throws CacheException {
+        return DISABLED_CACHE;
+    }
+
+    private static final class DisabledCache<K,V> implements Cache<K,V> {
+
+        public V get(K key) throws CacheException {
+            return null;
+        }
+
+        public V put(K key, V value) throws CacheException {
+            return null;
+        }
+
+        public V remove(K key) throws CacheException {
+            return null;
+        }
+
+        public void clear() throws CacheException {
+        }
+
+        public int size() {
+            return 0;
+        }
+
+        public Set<K> keys() {
+            return Collections.emptySet();
+        }
+
+        public Collection<V> values() {
+            return Collections.emptySet();
+        }
+    }
+}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -34,7 +34,7 @@
     <build>
         <plugins>
             <!-- collect the test classes so they can be referenced by other modules -->
-            <!-- <plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
@@ -44,7 +44,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin> -->
+            </plugin>
             <!-- <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/core/src/main/java/org/apache/shiro/account/Account.java
+++ b/core/src/main/java/org/apache/shiro/account/Account.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.account;
+
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * An {@code Account} is a unique identity within an {@link AccountStore AccountStore} that
+ * has a set of attributes.  An account may represent a human being, but this is not required - an account could
+ * represent a host, a server, a daemon - basically anything with an identity that might need to be authenticated or
+ * authorized to perform behavior.
+ * <h3>Implementation Warning</h3>
+ * Since Shiro sometimes logs account operations, please ensure your Account's <code>toString()</code>
+ * implementation does <em>not</em> print out account credentials (password, etc), as these might be viewable to
+ * someone reading your logs.  This is good practice anyway, and account principals should rarely (if ever) be printed
+ * out for any reason.
+ * <p/>
+ * Shiro's default implementations of this interface only ever print {@link #getAttributes() attributes}.
+ *
+ * @since 2.0
+ */
+public interface Account extends Serializable {
+
+    /**
+     * Returns an identifier unique compared to any other Account found in the same account store.  For example,
+     * this can be a store-wide unique username or email address, database primary key, UUID, GUID, etc.
+     * <p/>
+     * After an account is authenticated, Shiro will use this id for all future access to the account: for caching
+     * the account (if caching is enabled), for future lookups from the account store, and any lookups for authorization.
+     *
+     * @return an identifier unique compared to any other Account found in the same account store.
+     */
+    AccountId getId();
+
+    /**
+     * Returns the stored credentials associated with the corresponding Account.  Credentials, such as a password or
+     * private key, verifies one or more submitted identities during authentication.
+     * <p/>
+     * Shiro references credentials during the authentication process to ensure that submitted credentials
+     * during a login attempt match exactly the Account's stored credentials returned via this method.
+     *
+     * @return the credentials associated with the corresponding Subject.
+     */
+    Object getCredentials();
+
+    /**
+     * Returns an <b><em>immutable</em></b> view of the Account's attributes accessible to the application.
+     * Once the account is obtained, an application developer can access them as desired, for example:
+     * <pre>
+     * String username = (String)account.getAttributes().get("username");
+     * System.out.println("Welcome, " + username + "!");
+     * </pre>
+     *
+     * @return the Account's attributes accessible to the application.
+     */
+    Map<String, Object> getAttributes();
+
+}

--- a/core/src/main/java/org/apache/shiro/account/AccountId.java
+++ b/core/src/main/java/org/apache/shiro/account/AccountId.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.account;
+
+import java.io.Serializable;
+
+/**
+ * @since 2.0
+ */
+public interface AccountId extends Serializable {
+
+    String toString();
+}

--- a/core/src/main/java/org/apache/shiro/account/AccountStore.java
+++ b/core/src/main/java/org/apache/shiro/account/AccountStore.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.account;
+
+import org.apache.shiro.authc.AuthenticationToken;
+
+/**
+ * @since 2.0
+ */
+public interface AccountStore {
+
+    Account getAccount(AuthenticationToken token);
+
+    Account getAccount(AccountId id);
+
+}

--- a/core/src/main/java/org/apache/shiro/authc/AbstractAuthenticator.java
+++ b/core/src/main/java/org/apache/shiro/authc/AbstractAuthenticator.java
@@ -39,7 +39,9 @@ import java.util.Collection;
  * is perform the actual principal/credential verification process for the submitted {@code AuthenticationToken}.
  *
  * @since 0.1
+ * @deprecated since 2.0 in favor of {@link DefaultAuthenticator} or implementing {@link Authenticator} directly.
  */
+@Deprecated
 public abstract class AbstractAuthenticator implements Authenticator, LogoutAware {
 
     /*-------------------------------------------
@@ -185,6 +187,7 @@ public abstract class AbstractAuthenticator implements Authenticator, LogoutAwar
      * @throws AuthenticationException if there is any problem during the authentication process - see the
      *                                 interface's JavaDoc for a more detailed explanation.
      */
+    @Deprecated
     public final AuthenticationInfo authenticate(AuthenticationToken token) throws AuthenticationException {
 
         if (token == null) {
@@ -254,6 +257,4 @@ public abstract class AbstractAuthenticator implements Authenticator, LogoutAwar
      */
     protected abstract AuthenticationInfo doAuthenticate(AuthenticationToken token)
             throws AuthenticationException;
-
-
 }

--- a/core/src/main/java/org/apache/shiro/authc/Account.java
+++ b/core/src/main/java/org/apache/shiro/authc/Account.java
@@ -36,7 +36,9 @@ import org.apache.shiro.authz.AuthorizationInfo;
  *
  * @see SimpleAccount
  * @since 0.9
+ * @deprecated since 2.0 in favor of {@link org.apache.shiro.account.Account}
  */
+@Deprecated
 public interface Account extends AuthenticationInfo, AuthorizationInfo {
 
 }

--- a/core/src/main/java/org/apache/shiro/authc/AuthenticationEvent.java
+++ b/core/src/main/java/org/apache/shiro/authc/AuthenticationEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.authc;
+
+import org.apache.shiro.event.Event;
+
+/**
+ * @since 2.0
+ */
+public abstract class AuthenticationEvent extends Event {
+
+    private final AuthenticationToken token;
+
+    public AuthenticationEvent(Object source, AuthenticationToken token) {
+        super(source);
+        this.token = token;
+    }
+
+    public AuthenticationToken getAuthenticationToken() {
+        return token;
+    }
+}

--- a/core/src/main/java/org/apache/shiro/authc/AuthenticationInfo.java
+++ b/core/src/main/java/org/apache/shiro/authc/AuthenticationInfo.java
@@ -54,7 +54,9 @@ import java.io.Serializable;
  * @see org.apache.shiro.authz.AuthorizationInfo AuthorizationInfo
  * @see Account
  * @since 0.9
+ * @deprecated since 2.0 in favor of {@link org.apache.shiro.account.Account}.
  */
+@Deprecated
 public interface AuthenticationInfo extends Serializable {
 
     /**
@@ -66,7 +68,9 @@ public interface AuthenticationInfo extends Serializable {
      * as passwords, private keys, etc.  Those should be instead returned by {@link #getCredentials() getCredentials()}.
      *
      * @return all principals associated with the corresponding Subject.
+     * @deprecated since 2.0 in favor of {@link org.apache.shiro.account.Account#getAttributes()}.
      */
+    @Deprecated
     PrincipalCollection getPrincipals();
 
     /**

--- a/core/src/main/java/org/apache/shiro/authc/Authenticator.java
+++ b/core/src/main/java/org/apache/shiro/authc/Authenticator.java
@@ -19,12 +19,11 @@
 package org.apache.shiro.authc;
 
 /**
- * An Authenticator is responsible for authenticating accounts in an application.  It
- * is one of the primary entry points into the Shiro API.
+ * An Authenticator is responsible for authenticating accounts.
  * <p/>
  * Although not a requirement, there is usually a single 'master' Authenticator configured for
  * an application.  Enabling Pluggable Authentication Module (PAM) behavior
- * (Two Phase Commit, etc.) is usually achieved by the single {@code Authenticator} coordinating
+ * (Two Phase Commit, etc.) is usually achieved by the master {@code Authenticator} coordinating
  * and interacting with an application-configured set of {@link org.apache.shiro.realm.Realm Realm}s.
  * <p/>
  * Note that most Shiro users will not interact with an {@code Authenticator} instance directly.
@@ -39,7 +38,7 @@ package org.apache.shiro.authc;
 public interface Authenticator {
 
     /**
-     * Authenticates a user based on the submitted {@code AuthenticationToken}.
+     * Authenticates an account based on the submitted {@code AuthenticationToken}.
      * <p/>
      * If the authentication is successful, an {@link AuthenticationInfo} instance is returned that represents the
      * user's account data relevant to Shiro.  This returned object is generally used in turn to construct a
@@ -61,7 +60,35 @@ public interface Authenticator {
      * @see LockedAccountException
      * @see ConcurrentAccessException
      * @see UnknownAccountException
+     * @deprecated since 2.0 in favor of {@link #authenticateAccount(AuthenticationToken)}.
      */
-    public AuthenticationInfo authenticate(AuthenticationToken authenticationToken)
-            throws AuthenticationException;
+    @Deprecated
+    public AuthenticationInfo authenticate(AuthenticationToken authenticationToken) throws AuthenticationException;
+
+    /**
+     * Authenticates an account based on the submitted {@code AuthenticationToken}.
+     * <p/>
+     * If the authentication is successful, the {@link Account} instance representing data relevant to Shiro is
+     * returned.  The returned account is used by higher-level components to construct a
+     * {@code Subject} representing a more complete security-specific 'view' of an account that also allows access to
+     * a {@code Session}.
+     *
+     * @param authenticationToken any representation of an account's principals and credentials submitted during an
+     *                            authentication attempt.
+     * @return the authenticated account.
+     * @throws AuthenticationException if there is any problem during the authentication process.
+     *                                 See the specific exceptions listed below to as examples of what could happen
+     *                                 in order to accurately handle these problems and to notify the user in an
+     *                                 appropriate manner why the authentication attempt failed.  Realize an
+     *                                 implementation of this interface may or may not throw those listed or may
+     *                                 throw other AuthenticationExceptions, but the list shows the most common ones.
+     * @see ExpiredCredentialsException
+     * @see IncorrectCredentialsException
+     * @see ExcessiveAttemptsException
+     * @see LockedAccountException
+     * @see ConcurrentAccessException
+     * @see UnknownAccountException
+     * @since 2.0
+     */
+    public org.apache.shiro.account.Account authenticateAccount(AuthenticationToken authenticationToken) throws AuthenticationException;
 }

--- a/core/src/main/java/org/apache/shiro/authc/CompositeAccount.java
+++ b/core/src/main/java/org/apache/shiro/authc/CompositeAccount.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.authc;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @since 2.0
+ */
+public interface CompositeAccount extends org.apache.shiro.account.Account {
+
+    Set<String> getRealmNames();
+
+    void appendRealmAccount(String realmName, org.apache.shiro.account.Account account);
+
+    Map<String,Object> getRealmAttributes(String realmName);
+}

--- a/core/src/main/java/org/apache/shiro/authc/CompositeAccountId.java
+++ b/core/src/main/java/org/apache/shiro/authc/CompositeAccountId.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.authc;
+
+import org.apache.shiro.account.AccountId;
+
+/**
+ * @since 2.0
+ */
+public interface CompositeAccountId extends AccountId {
+
+    AccountId getRealmAccountId(String realmName);
+}

--- a/core/src/main/java/org/apache/shiro/authc/DefaultAuthenticator.java
+++ b/core/src/main/java/org/apache/shiro/authc/DefaultAuthenticator.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.authc;
+
+import org.apache.shiro.account.Account;
+import org.apache.shiro.authc.pam.UnsupportedTokenException;
+import org.apache.shiro.authc.strategy.AuthenticationStrategy;
+import org.apache.shiro.authc.strategy.DefaultAuthenticationAttempt;
+import org.apache.shiro.authc.strategy.FirstRealmSuccessfulStrategy;
+import org.apache.shiro.event.EventBus;
+import org.apache.shiro.event.EventBusAware;
+import org.apache.shiro.realm.Realm;
+import org.apache.shiro.util.Assert;
+import org.apache.shiro.util.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * @since 2.0
+ */
+public class DefaultAuthenticator implements Authenticator, EventBusAware {
+
+    private static final Logger log = LoggerFactory.getLogger(DefaultAuthenticator.class);
+
+    private Collection<Realm> realms;
+
+    private EventBus eventBus;
+
+    private AuthenticationStrategy authenticationStrategy;
+
+    public DefaultAuthenticator(){
+        //default in Shiro 2.0 is 'first successful'. This is the desired behavior for most Shiro users (80/20 rule).
+        // < 2.0 was 'at least one successful', which was often not desired and caused unnecessary I/O.
+        this.authenticationStrategy = new FirstRealmSuccessfulStrategy();
+    }
+
+    public Collection<Realm> getRealms() {
+        return realms;
+    }
+
+    public void setRealms(Collection<Realm> realms) {
+        this.realms = realms;
+    }
+
+    public EventBus getEventBus() {
+        return eventBus;
+    }
+
+    public void setEventBus(EventBus eventBus) {
+        this.eventBus = eventBus;
+    }
+
+    public AuthenticationStrategy getAuthenticationStrategy() {
+        return authenticationStrategy;
+    }
+
+    public void setAuthenticationStrategy(AuthenticationStrategy authenticationStrategy) {
+        this.authenticationStrategy = authenticationStrategy;
+    }
+
+    @Deprecated
+    public final AuthenticationInfo authenticate(AuthenticationToken token) throws AuthenticationException {
+        throw new UnsupportedOperationException("The " + getClass().getName() + " implementation does not support " +
+                "legacy (pre 2.0) authentication behavior.  Invoke 'authenticateAccount' instead.");
+    }
+
+    protected Account authenticateSingleRealmAccount(Realm realm, AuthenticationToken token) throws Throwable {
+        if (!realm.supports(token)) {
+            String msg = "Realm [" + realm + "] does not support authentication token [" +
+                    token + "].  Please ensure that the appropriate Realm implementation is " +
+                    "configured correctly or that the realm accepts AuthenticationTokens of this type.";
+            throw new UnsupportedTokenException(msg);
+        }
+        return realm.authenticateAccount(token);
+    }
+
+    protected Account authenticateMultiRealmAccount(Collection<Realm> realms, AuthenticationToken token) throws Throwable {
+        DefaultAuthenticationAttempt attempt =
+                new DefaultAuthenticationAttempt(token, Collections.unmodifiableCollection(realms));
+        return getAuthenticationStrategy().execute(attempt);
+    }
+
+    public Account authenticateAccount(AuthenticationToken token) throws AuthenticationException {
+
+        Assert.notNull(token, "AuthenticationToken argument cannot be null.");
+
+        log.trace("Authentication submission received for authentication token [{}]", token);
+
+        Account account;
+        try {
+            account = doAuthenticateAccount(token);
+            if (account == null) {
+                String msg = "No account returned by any configured realms for submitted authentication token ["
+                        + token + "].";
+                throw new UnknownAccountException(msg);
+            }
+        } catch (Throwable t) {
+            AuthenticationException ae = null;
+            if (t instanceof AuthenticationException) {
+                ae = (AuthenticationException) t;
+            }
+            if (ae == null) {
+                //Exception thrown was not an expected AuthenticationException.  Therefore it is probably a little more
+                //severe or unexpected.  So, wrap in an AuthenticationException, log to warn, and propagate:
+                String msg = "Authentication failed for submitted token [" + token + "].  Possible unexpected " +
+                        "error? (Typical or expected login exceptions should extend from AuthenticationException).";
+                ae = new AuthenticationException(msg, t);
+            }
+            try {
+                notifyFailure(token, ae);
+            } catch (Throwable t2) {
+                if (log.isWarnEnabled()) {
+                    String msg = "Unable to send notification for failed authentication attempt - listener error?.  " +
+                            "Please check your EventBus implementation.  Logging 'send' exception " +
+                            "and propagating original AuthenticationException instead...";
+                    log.warn(msg, t2);
+                }
+            }
+
+            throw ae;
+        }
+
+        log.debug("Authentication successful for submitted authentication token [{}].  Returned account [{}]",
+                token, account);
+
+        notifySuccess(token, account);
+
+        return account;
+    }
+
+    protected Account doAuthenticateAccount(AuthenticationToken token) throws Throwable {
+        Collection<Realm> realms = getRealms();
+        int size = CollectionUtils.size(realms);
+        Assert.isTrue(size > 0, "One or more realms must be configured to perform authentication.");
+
+        if (size == 1) {
+            return authenticateSingleRealmAccount(realms.iterator().next(), token);
+        }
+        return authenticateMultiRealmAccount(realms, token);
+    }
+
+    protected void notifySuccess(AuthenticationToken token, Account account) {
+        EventBus eventBus = getEventBus();
+        if (eventBus != null) {
+            SuccessfulAuthenticationEvent event = new SuccessfulAuthenticationEvent(this, token, account);
+            eventBus.publish(event);
+        }
+    }
+
+    protected void notifyFailure(AuthenticationToken token, Throwable t) {
+        EventBus eventBus = getEventBus();
+        if (eventBus != null) {
+            FailedAuthenticationEvent event = new FailedAuthenticationEvent(this, token, t);
+            eventBus.publish(event);
+        }
+    }
+}

--- a/core/src/main/java/org/apache/shiro/authc/DefaultCompositeAccount.java
+++ b/core/src/main/java/org/apache/shiro/authc/DefaultCompositeAccount.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.authc;
+
+import org.apache.shiro.account.AccountId;
+import org.apache.shiro.util.CollectionUtils;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @since 2.0
+ */
+public class DefaultCompositeAccount implements CompositeAccount {
+
+    // realm name - to - attributes from that realm
+    private final Map<String, Map<String, Object>> REALM_ATTRS = new LinkedHashMap<String, Map<String, Object>>();
+
+    private final Map<String, Object> MERGED_ATTRS = new LinkedHashMap<String, Object>();
+
+    private final DefaultCompositeAccountId id;
+
+    private final boolean overwrite;
+
+    public DefaultCompositeAccount() {
+        this(true);
+    }
+
+    public DefaultCompositeAccount(boolean overwrite) {
+        this.overwrite = overwrite;
+        this.id = new DefaultCompositeAccountId();
+    }
+
+    public AccountId getId() {
+        return this.id;
+    }
+
+    public Object getCredentials() {
+        //not needed: all accounts added to a composite have already been authenticated
+        return null;
+    }
+
+    public Map<String, Object> getAttributes() {
+        return Collections.unmodifiableMap(MERGED_ATTRS);
+    }
+
+    public Set<String> getRealmNames() {
+        return Collections.unmodifiableSet(REALM_ATTRS.keySet());
+    }
+
+    public void appendRealmAccount(String realmName, org.apache.shiro.account.Account account) {
+
+        this.id.setRealmAccountId(realmName, account.getId());
+
+        Map<String, Object> realmAttributes = account.getAttributes();
+        if (realmAttributes == null) {
+            realmAttributes = Collections.emptyMap();
+        }
+
+        REALM_ATTRS.put(realmName, realmAttributes);
+
+        for (String key : realmAttributes.keySet()) {
+            if (overwrite) {
+                MERGED_ATTRS.put(key, realmAttributes.get(key));
+            } else {
+                if (!MERGED_ATTRS.containsKey(key)) {
+                    MERGED_ATTRS.put(key, realmAttributes.get(key));
+                }
+            }
+        }
+    }
+
+    public Map<String, Object> getRealmAttributes(String realmName) {
+        Map<String, Object> attrs = REALM_ATTRS.get(realmName);
+        if (CollectionUtils.isEmpty(attrs)) {
+            return Collections.emptyMap();
+        }
+        return Collections.unmodifiableMap(attrs);
+    }
+}

--- a/core/src/main/java/org/apache/shiro/authc/DefaultCompositeAccountId.java
+++ b/core/src/main/java/org/apache/shiro/authc/DefaultCompositeAccountId.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.authc;
+
+import org.apache.shiro.account.AccountId;
+import org.apache.shiro.util.Assert;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * @since 2.0
+ */
+public class DefaultCompositeAccountId implements CompositeAccountId {
+
+    private Map<String,AccountId> REALM_ACCOUNTIDS = new LinkedHashMap<String,AccountId>();
+
+    public AccountId getRealmAccountId(String realmName) {
+        return realmName != null ? REALM_ACCOUNTIDS.get(realmName) : null;
+    }
+
+    public void setRealmAccountId(String realmName, AccountId accountId) {
+        Assert.hasText(realmName, "realmName must have text.");
+        Assert.notNull(accountId, "accountId cannot be null.");
+        REALM_ACCOUNTIDS.put(realmName, accountId);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (o instanceof DefaultCompositeAccountId) {
+            DefaultCompositeAccountId impl = (DefaultCompositeAccountId)o;
+            return REALM_ACCOUNTIDS.equals(impl.REALM_ACCOUNTIDS);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return REALM_ACCOUNTIDS.isEmpty() ? 0 : REALM_ACCOUNTIDS.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        if (REALM_ACCOUNTIDS.isEmpty()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        for(String realmName : REALM_ACCOUNTIDS.keySet()) {
+            if (sb.length() > 0) {
+                sb.append(", ");
+            }
+            sb.append(realmName).append(": ").append(REALM_ACCOUNTIDS.get(realmName));
+        }
+        return sb.toString();
+    }
+}

--- a/core/src/main/java/org/apache/shiro/authc/FailedAuthenticationEvent.java
+++ b/core/src/main/java/org/apache/shiro/authc/FailedAuthenticationEvent.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.authc;
+
+/**
+ * @since 2.0
+ */
+public class FailedAuthenticationEvent extends AuthenticationEvent {
+
+    final Throwable throwable;
+
+    public FailedAuthenticationEvent(Object source, AuthenticationToken token, Throwable throwable) {
+        super(source, token);
+        this.throwable = throwable;
+    }
+
+    public Throwable getThrowable() {
+        return throwable;
+    }
+}

--- a/core/src/main/java/org/apache/shiro/authc/MergableAuthenticationInfo.java
+++ b/core/src/main/java/org/apache/shiro/authc/MergableAuthenticationInfo.java
@@ -31,7 +31,9 @@ package org.apache.shiro.authc;
  * realm/data source.
  *
  * @since 0.9
+ * @deprecated since 2.0 in favor of {@link CompositeAccount}
  */
+@Deprecated
 public interface MergableAuthenticationInfo extends AuthenticationInfo {
 
     /**

--- a/core/src/main/java/org/apache/shiro/authc/SaltedAuthenticationInfo.java
+++ b/core/src/main/java/org/apache/shiro/authc/SaltedAuthenticationInfo.java
@@ -36,7 +36,9 @@ import org.apache.shiro.util.ByteSource;
  * @see org.apache.shiro.authc.credential.HashedCredentialsMatcher
  *
  * @since 1.1
+ * @deprecated since 2.0 in favor of using a {@link org.apache.shiro.authc.credential.PasswordMatcher}
  */
+@Deprecated
 public interface SaltedAuthenticationInfo extends AuthenticationInfo {
 
     /**

--- a/core/src/main/java/org/apache/shiro/authc/SimpleAccount.java
+++ b/core/src/main/java/org/apache/shiro/authc/SimpleAccount.java
@@ -28,19 +28,20 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Set;
 
-
 /**
  * Simple implementation of the {@link org.apache.shiro.authc.Account} interface that
  * contains principal and credential and authorization information (roles and permissions) as instance variables and
  * exposes them via getters and setters using standard JavaBean notation.
  *
  * @since 0.1
+ * @deprecated since 2.0 in favor of an {@link org.apache.shiro.account.Account Account} implementation.
  */
+@Deprecated
 public class SimpleAccount implements Account, MergableAuthenticationInfo, SaltedAuthenticationInfo, Serializable {
 
     /*--------------------------------------------
-    |    I N S T A N C E   V A R I A B L E S    |
-    ============================================*/
+     |    I N S T A N C E   V A R I A B L E S    |
+     ============================================*/
     /**
      * The authentication information (principals and credentials) for this account.
      */

--- a/core/src/main/java/org/apache/shiro/authc/SimpleAuthenticationInfo.java
+++ b/core/src/main/java/org/apache/shiro/authc/SimpleAuthenticationInfo.java
@@ -34,7 +34,9 @@ import java.util.Set;
  *
  * @see org.apache.shiro.realm.AuthenticatingRealm
  * @since 0.9
+ * @deprecated since 2.0 in favor of an {@link org.apache.shiro.account.Account Account} implementation.
  */
+@Deprecated
 public class SimpleAuthenticationInfo implements MergableAuthenticationInfo, SaltedAuthenticationInfo {
 
     /**

--- a/core/src/main/java/org/apache/shiro/authc/SuccessfulAuthenticationEvent.java
+++ b/core/src/main/java/org/apache/shiro/authc/SuccessfulAuthenticationEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.authc;
+
+import org.apache.shiro.account.Account;
+
+/**
+ * @since 2.0
+ */
+public class SuccessfulAuthenticationEvent extends AuthenticationEvent {
+
+    final org.apache.shiro.account.Account account;
+
+    public SuccessfulAuthenticationEvent(Object source, AuthenticationToken token, org.apache.shiro.account.Account account) {
+        super(source, token);
+        this.account = account;
+    }
+
+    public Account getAccount() {
+        return account;
+    }
+}

--- a/core/src/main/java/org/apache/shiro/authc/credential/AllowAllCredentialsMatcher.java
+++ b/core/src/main/java/org/apache/shiro/authc/credential/AllowAllCredentialsMatcher.java
@@ -18,26 +18,50 @@
  */
 package org.apache.shiro.authc.credential;
 
+import org.apache.shiro.account.Account;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
 
 /**
  * A credentials matcher that always returns {@code true} when matching credentials no matter what arguments
- * are passed in.  This can be used for testing or when credentials are implicitly trusted for a particular
- * {@link org.apache.shiro.realm.Realm Realm}.
+ * are passed in. Configuring this matcher on a Realm effectively disables the Realm from performing any credentials
+ * comparisons itself.
+ * <p/>
+ * While this might sound unintuitive ("why would you disable the realm from asserting correct credentials?"), this
+ * matcher can be useful when the Realm does not do the credentials matching directly, but instead lets an underlying
+ * {@link org.apache.shiro.account.AccountStore AccountStore} do the credentials checking directly.
+ * <p/>
+ * This is common for example, in LDAP or ActiveDirectory scenarios: if you query LDAP for the account record using
+ * the credentials submitted in the {@code AuthenticationToken}, the LDAP server will automatically authenticate the
+ * query request before returning the account record.  In this (and similar) authenticated request scenarios, there is
+ * no further authentication for the Realm to perform itself, so it can use this {@code AllowAllCredentialsMatcher},
+ * effectively trusting the underlying account store to do the authentication work.
  *
  * @since 0.2
  */
 public class AllowAllCredentialsMatcher implements CredentialsMatcher {
 
     /**
-     * Returns <code>true</code> <em>always</em> no matter what the method arguments are.
+     * Returns {@code true} <em>always</em>, ignoring the method arguments.
      *
-     * @param token   the token submitted for authentication.
-     * @param info    the account being verified for access
-     * @return <code>true</code> <em>always</em>.
+     * @param token the token submitted for authentication.
+     * @param info  the account being verified for access
+     * @return {@code true} <em>always</em>, ignoring the method arguments.
+     * @deprecated in favor of {@link #credentialsMatch(org.apache.shiro.authc.AuthenticationToken, org.apache.shiro.account.Account)}
      */
+    @Deprecated
     public boolean doCredentialsMatch(AuthenticationToken token, AuthenticationInfo info) {
+        return true;
+    }
+
+    /**
+     * Returns {@code true} <em>always</em>, ignoring the method arguments.
+     *
+     * @param token   ignored
+     * @param account ignored
+     * @return {@code true} <em>always</em>, ignoring the method arguments.
+     */
+    public boolean credentialsMatch(AuthenticationToken token, Account account) {
         return true;
     }
 }

--- a/core/src/main/java/org/apache/shiro/authc/credential/CredentialsMatcher.java
+++ b/core/src/main/java/org/apache/shiro/authc/credential/CredentialsMatcher.java
@@ -18,6 +18,7 @@
  */
 package org.apache.shiro.authc.credential;
 
+import org.apache.shiro.account.Account;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
 
@@ -25,17 +26,15 @@ import org.apache.shiro.authc.AuthenticationToken;
 /**
  * Interface implemented by classes that can determine if an AuthenticationToken's provided
  * credentials matches a corresponding account's credentials stored in the system.
- *
+ * <p/>
  * <p>Simple direct comparisons are handled well by the
  * {@link SimpleCredentialsMatcher SimpleCredentialsMatcher}.  If you
- * hash user's credentials before storing them in a realm (a common practice), look at the
- * {@link HashedCredentialsMatcher HashedCredentialsMatcher} implementations,
- * as they support this scenario.
+ * hash user's credentials (passwords) before storing them in a realm (a common practice), look at the
+ * {@link PasswordMatcher PasswordMatcher}.
  *
+ * @see PasswordMatcher
  * @see SimpleCredentialsMatcher
  * @see AllowAllCredentialsMatcher
- * @see Md5CredentialsMatcher
- * @see Sha1CredentialsMatcher
  * @since 0.1
  */
 public interface CredentialsMatcher {
@@ -44,11 +43,25 @@ public interface CredentialsMatcher {
      * Returns {@code true} if the provided token credentials match the stored account credentials,
      * {@code false} otherwise.
      *
+     * @param token the {@code AuthenticationToken} submitted during the authentication attempt
+     * @param info  the {@code AuthenticationInfo} stored in the system.
+     * @return {@code true} if the provided token credentials match the stored account credentials,
+     *         {@code false} otherwise.
+     * @deprecated since 2.0 in favor of {@link #credentialsMatch(org.apache.shiro.authc.AuthenticationToken, org.apache.shiro.account.Account)}
+     */
+    @Deprecated
+    boolean doCredentialsMatch(AuthenticationToken token, AuthenticationInfo info);
+
+    /**
+     * Returns {@code true} if the provided token credentials match the stored account credentials,
+     * {@code false} otherwise.
+     *
      * @param token   the {@code AuthenticationToken} submitted during the authentication attempt
-     * @param info the {@code AuthenticationInfo} stored in the system.
+     * @param account the stored {@code Account} found based on the submitted token
+     *                {@link org.apache.shiro.authc.AuthenticationToken#getPrincipal() principal}.
      * @return {@code true} if the provided token credentials match the stored account credentials,
      *         {@code false} otherwise.
      */
-    boolean doCredentialsMatch(AuthenticationToken token, AuthenticationInfo info);
+    boolean credentialsMatch(AuthenticationToken token, Account account);
 
 }

--- a/core/src/main/java/org/apache/shiro/authc/credential/DefaultPasswordService.java
+++ b/core/src/main/java/org/apache/shiro/authc/credential/DefaultPasswordService.java
@@ -22,17 +22,19 @@ import org.apache.shiro.crypto.hash.DefaultHashService;
 import org.apache.shiro.crypto.hash.Hash;
 import org.apache.shiro.crypto.hash.HashRequest;
 import org.apache.shiro.crypto.hash.HashService;
-import org.apache.shiro.crypto.hash.format.*;
+import org.apache.shiro.crypto.hash.format.DefaultHashFormatFactory;
+import org.apache.shiro.crypto.hash.format.HashFormat;
+import org.apache.shiro.crypto.hash.format.HashFormatFactory;
+import org.apache.shiro.crypto.hash.format.ParsableHashFormat;
+import org.apache.shiro.crypto.hash.format.Shiro1CryptFormat;
 import org.apache.shiro.util.ByteSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Default implementation of the {@link PasswordService} interface that relies on an internal
- * {@link HashService}, {@link HashFormat}, and {@link HashFormatFactory} to function:
- * <h2>Hashing Passwords</h2>
- *
- * <h2>Comparing Passwords</h2>
+ * {@link HashService}, {@link HashFormat}, and {@link HashFormatFactory} to function.
+ * <p/>
  * All hashing operations are performed by the internal {@link #getHashService() hashService}.  After the hash
  * is computed, it is formatted into a String value via the internal {@link #getHashFormat() hashFormat}.
  *

--- a/core/src/main/java/org/apache/shiro/authc/credential/HashedCredentialsMatcher.java
+++ b/core/src/main/java/org/apache/shiro/authc/credential/HashedCredentialsMatcher.java
@@ -18,6 +18,7 @@
  */
 package org.apache.shiro.authc.credential;
 
+import org.apache.shiro.account.Account;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.authc.SaltedAuthenticationInfo;
@@ -116,7 +117,9 @@ import org.apache.shiro.util.StringUtils;
  * @see org.apache.shiro.crypto.hash.Sha1Hash
  * @see org.apache.shiro.crypto.hash.Sha256Hash
  * @since 0.9
+ * @deprecated since 2.0 in favor of {@link PasswordMatcher} or implementing {@link CredentialsMatcher} directly.
  */
+@Deprecated
 public class HashedCredentialsMatcher extends SimpleCredentialsMatcher {
 
     /**
@@ -381,6 +384,16 @@ public class HashedCredentialsMatcher extends SimpleCredentialsMatcher {
         return equals(tokenHashedCredentials, accountCredentials);
     }
 
+    @Override
+    public boolean credentialsMatch(AuthenticationToken token, Account account) {
+        throw new UnsupportedOperationException("In Shiro 2.0, the " + HashedCredentialsMatcher.class.getName() +
+                " is deprecated.  Password comparisons should performed by a PasswordMatcher or by implementing " +
+                "the " + CredentialsMatcher.class.getName() + " interface directly.");
+        //Object tokenHashedCredentials = hashProvidedCredentials(token, account);
+        //Object accountCredentials = getCredentials(account);
+        //return equals(tokenHashedCredentials, accountCredentials);
+    }
+
     /**
      * Hash the provided {@code token}'s credentials using the salt stored with the account if the
      * {@code info} instance is an {@code instanceof} {@link SaltedAuthenticationInfo SaltedAuthenticationInfo} (see
@@ -455,5 +468,4 @@ public class HashedCredentialsMatcher extends SimpleCredentialsMatcher {
         String hashAlgorithmName = assertHashAlgorithmName();
         return new SimpleHash(hashAlgorithmName);
     }
-
 }

--- a/core/src/main/java/org/apache/shiro/authc/credential/Md2CredentialsMatcher.java
+++ b/core/src/main/java/org/apache/shiro/authc/credential/Md2CredentialsMatcher.java
@@ -18,8 +18,6 @@
  */
 package org.apache.shiro.authc.credential;
 
-import org.apache.shiro.crypto.hash.AbstractHash;
-import org.apache.shiro.crypto.hash.Hash;
 import org.apache.shiro.crypto.hash.Md2Hash;
 
 
@@ -34,8 +32,7 @@ import org.apache.shiro.crypto.hash.Md2Hash;
  * supporting <code>CredentialsMatcher</code> implementations.</p>
  *
  * @since 0.9
- * @deprecated since 1.1 - use the HashedCredentialsMatcher directly and set its
- *             {@link HashedCredentialsMatcher#setHashAlgorithmName(String) hashAlgorithmName} property.
+ * @deprecated since 2.0 in favor of {@link PasswordMatcher} or implementing {@link CredentialsMatcher} directly.
  */
 @Deprecated
 public class Md2CredentialsMatcher extends HashedCredentialsMatcher {

--- a/core/src/main/java/org/apache/shiro/authc/credential/Md5CredentialsMatcher.java
+++ b/core/src/main/java/org/apache/shiro/authc/credential/Md5CredentialsMatcher.java
@@ -18,8 +18,6 @@
  */
 package org.apache.shiro.authc.credential;
 
-import org.apache.shiro.crypto.hash.AbstractHash;
-import org.apache.shiro.crypto.hash.Hash;
 import org.apache.shiro.crypto.hash.Md5Hash;
 
 
@@ -34,9 +32,9 @@ import org.apache.shiro.crypto.hash.Md5Hash;
  * supporting <code>CredentialsMatcher</code> implementations.</p>
  *
  * @since 0.9
- * @deprecated since 1.1 - use the HashedCredentialsMatcher directly and set its
- *             {@link HashedCredentialsMatcher#setHashAlgorithmName(String) hashAlgorithmName} property.
+ * @deprecated since 2.0 in favor of {@link PasswordMatcher} or implementing {@link CredentialsMatcher} directly.
  */
+@Deprecated
 public class Md5CredentialsMatcher extends HashedCredentialsMatcher {
 
     public Md5CredentialsMatcher() {

--- a/core/src/main/java/org/apache/shiro/authc/credential/PasswordService.java
+++ b/core/src/main/java/org/apache/shiro/authc/credential/PasswordService.java
@@ -54,10 +54,10 @@ import org.apache.shiro.util.ByteSource;
  * <pre>
  * [main]
  * ...
- * passwordService = org.apache.shiro.authc.credential.DefaultPasswordService
+ * passwordService = {@link org.apache.shiro.authc.credential.DefaultPasswordService org.apache.shiro.authc.credential.DefaultPasswordService}
  * # configure the passwordService to use the settings you desire
  * ...
- * passwordMatcher = org.apache.shiro.authc.credential.PasswordMatcher
+ * passwordMatcher = {@link org.apache.shiro.authc.credential.PasswordMatcher org.apache.shiro.authc.credential.PasswordMatcher}
  * passwordMatcher.passwordService = $passwordService
  * ...
  * # Finally, set the matcher on a realm that requires password matching for account authentication:

--- a/core/src/main/java/org/apache/shiro/authc/credential/Sha1CredentialsMatcher.java
+++ b/core/src/main/java/org/apache/shiro/authc/credential/Sha1CredentialsMatcher.java
@@ -18,8 +18,6 @@
  */
 package org.apache.shiro.authc.credential;
 
-import org.apache.shiro.crypto.hash.AbstractHash;
-import org.apache.shiro.crypto.hash.Hash;
 import org.apache.shiro.crypto.hash.Sha1Hash;
 
 
@@ -34,9 +32,9 @@ import org.apache.shiro.crypto.hash.Sha1Hash;
  * supporting <code>CredentialsMatcher</code> implementations.</p>
  *
  * @since 0.9
- * @deprecated since 1.1 - use the HashedCredentialsMatcher directly and set its
- *             {@link HashedCredentialsMatcher#setHashAlgorithmName(String) hashAlgorithmName} property.
+ * @deprecated since 2.0 in favor of {@link PasswordMatcher} or implementing {@link CredentialsMatcher} directly.
  */
+@Deprecated
 public class Sha1CredentialsMatcher extends HashedCredentialsMatcher {
 
     public Sha1CredentialsMatcher() {

--- a/core/src/main/java/org/apache/shiro/authc/credential/Sha256CredentialsMatcher.java
+++ b/core/src/main/java/org/apache/shiro/authc/credential/Sha256CredentialsMatcher.java
@@ -18,8 +18,6 @@
  */
 package org.apache.shiro.authc.credential;
 
-import org.apache.shiro.crypto.hash.AbstractHash;
-import org.apache.shiro.crypto.hash.Hash;
 import org.apache.shiro.crypto.hash.Sha256Hash;
 
 
@@ -28,9 +26,9 @@ import org.apache.shiro.crypto.hash.Sha256Hash;
  * SHA-256 hashed.
  *
  * @since 0.9
- * @deprecated since 1.1 - use the HashedCredentialsMatcher directly and set its
- *             {@link HashedCredentialsMatcher#setHashAlgorithmName(String) hashAlgorithmName} property.
+ * @deprecated since 2.0 in favor of {@link PasswordMatcher} or implementing {@link CredentialsMatcher} directly.
  */
+@Deprecated
 public class Sha256CredentialsMatcher extends HashedCredentialsMatcher {
 
     public Sha256CredentialsMatcher() {

--- a/core/src/main/java/org/apache/shiro/authc/credential/Sha384CredentialsMatcher.java
+++ b/core/src/main/java/org/apache/shiro/authc/credential/Sha384CredentialsMatcher.java
@@ -18,8 +18,6 @@
  */
 package org.apache.shiro.authc.credential;
 
-import org.apache.shiro.crypto.hash.AbstractHash;
-import org.apache.shiro.crypto.hash.Hash;
 import org.apache.shiro.crypto.hash.Sha384Hash;
 
 
@@ -28,9 +26,9 @@ import org.apache.shiro.crypto.hash.Sha384Hash;
  * SHA-384 hashed.
  *
  * @since 0.9
- * @deprecated since 1.1 - use the HashedCredentialsMatcher directly and set its
- *             {@link HashedCredentialsMatcher#setHashAlgorithmName(String) hashAlgorithmName} property.
+ * @deprecated since 2.0 in favor of {@link PasswordMatcher} or implementing {@link CredentialsMatcher} directly.
  */
+@Deprecated
 public class Sha384CredentialsMatcher extends HashedCredentialsMatcher {
 
     public Sha384CredentialsMatcher() {

--- a/core/src/main/java/org/apache/shiro/authc/credential/Sha512CredentialsMatcher.java
+++ b/core/src/main/java/org/apache/shiro/authc/credential/Sha512CredentialsMatcher.java
@@ -18,8 +18,6 @@
  */
 package org.apache.shiro.authc.credential;
 
-import org.apache.shiro.crypto.hash.AbstractHash;
-import org.apache.shiro.crypto.hash.Hash;
 import org.apache.shiro.crypto.hash.Sha512Hash;
 
 
@@ -28,9 +26,9 @@ import org.apache.shiro.crypto.hash.Sha512Hash;
  * SHA-512 hashed.
  *
  * @since 0.9
- * @deprecated since 1.1 - use the HashedCredentialsMatcher directly and set its
- *             {@link HashedCredentialsMatcher#setHashAlgorithmName(String) hashAlgorithmName} property.
+ * @deprecated since 2.0 in favor of {@link PasswordMatcher} or implementing {@link CredentialsMatcher} directly.
  */
+@Deprecated
 public class Sha512CredentialsMatcher extends HashedCredentialsMatcher {
 
     public Sha512CredentialsMatcher() {

--- a/core/src/main/java/org/apache/shiro/authc/pam/AbstractAuthenticationStrategy.java
+++ b/core/src/main/java/org/apache/shiro/authc/pam/AbstractAuthenticationStrategy.java
@@ -18,7 +18,11 @@
  */
 package org.apache.shiro.authc.pam;
 
-import org.apache.shiro.authc.*;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.MergableAuthenticationInfo;
+import org.apache.shiro.authc.SimpleAuthenticationInfo;
 import org.apache.shiro.realm.Realm;
 
 import java.util.Collection;
@@ -29,7 +33,10 @@ import java.util.Collection;
  * implementations.
  *
  * @since 0.9
+ * @deprecated since 2.0: there is no longer a need for this intermediate abstract class.  Just implement the
+ * {@link org.apache.shiro.authc.strategy.AuthenticationStrategy} interface directly.
  */
+@Deprecated
 public abstract class AbstractAuthenticationStrategy implements AuthenticationStrategy {
 
     /**

--- a/core/src/main/java/org/apache/shiro/authc/pam/AllSuccessfulStrategy.java
+++ b/core/src/main/java/org/apache/shiro/authc/pam/AllSuccessfulStrategy.java
@@ -18,14 +18,13 @@
  */
 package org.apache.shiro.authc.pam;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.authc.UnknownAccountException;
 import org.apache.shiro.realm.Realm;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -37,7 +36,9 @@ import org.apache.shiro.realm.Realm;
  * associated subject (user).
  *
  * @since 0.2
+ * @deprecated since 2.0 in favor of {@link org.apache.shiro.authc.strategy.AllRealmsSuccessfulStrategy}
  */
+@Deprecated
 public class AllSuccessfulStrategy extends AbstractAuthenticationStrategy {
 
     /** Private class log instance. */

--- a/core/src/main/java/org/apache/shiro/authc/pam/AtLeastOneSuccessfulStrategy.java
+++ b/core/src/main/java/org/apache/shiro/authc/pam/AtLeastOneSuccessfulStrategy.java
@@ -38,7 +38,9 @@ import org.apache.shiro.subject.PrincipalCollection;
  *
  * @see FirstSuccessfulStrategy FirstSuccessfulAuthenticationStrategy
  * @since 0.2
+ * @deprecated since 2.0 in favor of {@link org.apache.shiro.authc.strategy.AtLeastOneRealmSuccessfulStrategy}
  */
+@Deprecated
 public class AtLeastOneSuccessfulStrategy extends AbstractAuthenticationStrategy {
 
     private static boolean isEmpty(PrincipalCollection pc) {

--- a/core/src/main/java/org/apache/shiro/authc/pam/AuthenticationStrategy.java
+++ b/core/src/main/java/org/apache/shiro/authc/pam/AuthenticationStrategy.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 
 
 /**
+ * <h1>Deprecated in 2.0</h1>
  * A {@code AuthenticationStrategy} implementation assists the {@link ModularRealmAuthenticator} during the
  * log-in process in a pluggable realm (PAM) environment.
  *
@@ -34,11 +35,10 @@ import java.util.Collection;
  * interaction with the configured Realms.  This allows a pluggable strategy of whether or not an authentication
  * attempt must be successful for all realms, only 1 or more realms, no realms, etc.
  *
- * @see AllSuccessfulStrategy
- * @see AtLeastOneSuccessfulStrategy
- * @see FirstSuccessfulStrategy
  * @since 0.2
+ * @deprecated since 2.0 in favor of {@link org.apache.shiro.authc.strategy.AuthenticationStrategy}.
  */
+@Deprecated
 public interface AuthenticationStrategy {
 
     /**

--- a/core/src/main/java/org/apache/shiro/authc/pam/FirstSuccessfulStrategy.java
+++ b/core/src/main/java/org/apache/shiro/authc/pam/FirstSuccessfulStrategy.java
@@ -34,7 +34,9 @@ import java.util.Collection;
  *
  * @see AtLeastOneSuccessfulStrategy AtLeastOneSuccessfulAuthenticationStrategy
  * @since 0.9
+ * @deprecated since 2.0 in favor of {@link org.apache.shiro.authc.strategy.FirstRealmSuccessfulStrategy}
  */
+@Deprecated
 public class FirstSuccessfulStrategy extends AbstractAuthenticationStrategy {
 
     /**

--- a/core/src/main/java/org/apache/shiro/authc/pam/UnsupportedTokenException.java
+++ b/core/src/main/java/org/apache/shiro/authc/pam/UnsupportedTokenException.java
@@ -28,7 +28,9 @@ import org.apache.shiro.authc.AuthenticationException;
  *
  * @see org.apache.shiro.authc.pam.AuthenticationStrategy
  * @since 0.2
+ * @deprecated since 2.0 as this was only thrown by legacy {@link org.apache.shiro.authc.pam.AuthenticationStrategy} implementations.
  */
+@Deprecated
 public class UnsupportedTokenException extends AuthenticationException {
 
     /**

--- a/core/src/main/java/org/apache/shiro/authc/pam/package-info.java
+++ b/core/src/main/java/org/apache/shiro/authc/pam/package-info.java
@@ -28,5 +28,6 @@
  * How the <code>ModularRealmAuthenticator</code> actually coordinates this behavior is configurable based on your
  * application's needs using an injectible
  * {@link AuthenticationStrategy}.
+ * @deprecated since 2.0 in favor of the {@link org.apache.shiro.authc.strategy} package.
  */
 package org.apache.shiro.authc.pam;

--- a/core/src/main/java/org/apache/shiro/authc/strategy/AllRealmsSuccessfulStrategy.java
+++ b/core/src/main/java/org/apache/shiro/authc/strategy/AllRealmsSuccessfulStrategy.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.authc.strategy;
+
+import org.apache.shiro.account.Account;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.DefaultCompositeAccount;
+import org.apache.shiro.realm.Realm;
+
+/**
+ * @since 2.0
+ */
+public class AllRealmsSuccessfulStrategy implements AuthenticationStrategy {
+
+    public Account execute(AuthenticationAttempt attempt) throws AuthenticationException {
+
+        AuthenticationToken token = attempt.getAuthenticationToken();
+
+        String firstAccountRealmName = null;
+        Account firstAccount = null;
+        DefaultCompositeAccount compositeAccount = null;
+
+        for(Realm realm : attempt.getRealms()) {
+
+            if (realm.supports(token)) {
+
+                // If the realm throws an exception, the loop will short circuit and this method will
+                // return.  As an 'all successful' strategy, if there is even a single exception thrown by any of the
+                // supported realms, the authentication attempt is unsuccessful.
+                //
+                // This particular implementation also favors short circuiting immediately (instead of trying all
+                // realms and then aggregating all potential exceptions) because continuing to access additional
+                // account stores is likely to incur unnecessary / undesirable I/O for most apps.
+                Account account = realm.authenticateAccount(token);
+
+                if (account != null) {
+                    if (firstAccount == null) {
+                        firstAccount = account;
+                        firstAccountRealmName = realm.getName();
+                    } else {
+                        if (compositeAccount == null) {
+                            compositeAccount = new DefaultCompositeAccount();
+                            compositeAccount.appendRealmAccount(firstAccountRealmName, firstAccount);
+                        }
+                        compositeAccount.appendRealmAccount(realm.getName(), account);
+                    }
+                }
+            }
+        }
+
+        if (compositeAccount != null) {
+            return compositeAccount;
+        }
+
+        return firstAccount;
+    }
+}

--- a/core/src/main/java/org/apache/shiro/authc/strategy/AtLeastOneRealmSuccessfulStrategy.java
+++ b/core/src/main/java/org/apache/shiro/authc/strategy/AtLeastOneRealmSuccessfulStrategy.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.authc.strategy;
+
+import org.apache.shiro.account.Account;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.DefaultCompositeAccount;
+import org.apache.shiro.realm.Realm;
+import org.apache.shiro.util.CollectionUtils;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * @since 2.0
+ */
+public class AtLeastOneRealmSuccessfulStrategy implements AuthenticationStrategy {
+
+    public Account execute(AuthenticationAttempt attempt) throws AuthenticationException {
+
+        AuthenticationToken token = attempt.getAuthenticationToken();
+
+        String firstAccountRealmName = null;
+        Account firstAccount = null;
+        DefaultCompositeAccount compositeAccount = null;
+
+        Map<String, Throwable> realmErrors = new LinkedHashMap<String, Throwable>();
+
+        for (Realm realm : attempt.getRealms()) {
+
+            if (realm.supports(token)) {
+
+                String realmName = realm.getName();
+
+                Account account;
+                try {
+                    account = realm.authenticateAccount(token);
+                } catch (Throwable t) {
+                    //noinspection ThrowableResultOfMethodCallIgnored
+                    realmErrors.put(realmName, t);
+                    continue;
+                }
+
+                if (account != null) {
+                    if (firstAccount == null) {
+                        firstAccount = account;
+                        firstAccountRealmName = realmName;
+                    } else {
+                        if (compositeAccount == null) {
+                            compositeAccount = new DefaultCompositeAccount();
+                            compositeAccount.appendRealmAccount(firstAccountRealmName, firstAccount);
+                        }
+                        compositeAccount.appendRealmAccount(realmName, account);
+                    }
+                }
+            }
+        }
+
+        if (compositeAccount != null) {
+            return compositeAccount;
+        }
+        if (firstAccount != null) {
+            return firstAccount;
+        }
+        if (!CollectionUtils.isEmpty(realmErrors)) {
+            throw new MultiRealmAuthenticationException(realmErrors);
+        }
+
+        return null;
+    }
+
+}

--- a/core/src/main/java/org/apache/shiro/authc/strategy/AuthenticationAttempt.java
+++ b/core/src/main/java/org/apache/shiro/authc/strategy/AuthenticationAttempt.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.authc.strategy;
+
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.realm.Realm;
+
+import java.util.Collection;
+
+/**
+ * An {@code AuthenticationAttempt} encapsulates all information required for an
+ * {@link AuthenticationStrategy} to perform a multi-realm authentication submission.
+ *
+ * @see DefaultAuthenticationAttempt
+ * @since 2.0
+ */
+public interface AuthenticationAttempt {
+
+    /**
+     * Returns the submitted authentication token for which an authenticated account may be returned.
+     *
+     * @return the submitted authentication token for which an authenticated account may be returned.
+     */
+    AuthenticationToken getAuthenticationToken();
+
+    /**
+     * Returns the realms to consult to authenticate the associated {@link #getAuthenticationToken() authenticationToken}.
+     *
+     * @return the realms to consult to authenticate the associated {@link #getAuthenticationToken() authenticationToken}.
+     */
+    Collection<Realm> getRealms();
+}

--- a/core/src/main/java/org/apache/shiro/authc/strategy/AuthenticationStrategy.java
+++ b/core/src/main/java/org/apache/shiro/authc/strategy/AuthenticationStrategy.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.authc.strategy;
+
+import org.apache.shiro.account.Account;
+import org.apache.shiro.authc.AuthenticationException;
+
+/**
+ * A{@code AuthenticationStrategy} implementation attempts to authenticate an account by consulting one or more
+ * {@link org.apache.shiro.realm.Realm Realm}s. This interface enables the
+ * <a href="http://en.wikipedia.org/wiki/Strategy_pattern">Strategy Design Pattern</a> for authentication, allowing a
+ * Shiro user to customize an {@link org.apache.shiro.authc.Authenticator Authenticator}'s authentication processing
+ * logic.
+ * <p/>
+ * Most Shiro users will find one of the existing Strategy implementations suitable for most needs, but if those are
+ * not sufficient, custom logic can be performed by implementing this interface.
+ *
+ * @see FirstRealmSuccessfulStrategy
+ * @see AllRealmsSuccessfulStrategy
+ * @see FirstRealmSuccessfulStrategy
+ * @see org.apache.shiro.authc.DefaultAuthenticator DefaultAuthenticator
+ * @since 2.0
+ */
+public interface AuthenticationStrategy {
+
+    /**
+     * Authenticates a submitted authentication token by consulting one or more provided
+     * {@link org.apache.shiro.authc.strategy.AuthenticationAttempt#getRealms() realms} and returns an
+     * {@link Account} instance reflecting the authenticated identity, or {@code null} if no account could be
+     * returned.
+     *
+     * @param attempt the attempt instance encompassing the submitted {@link org.apache.shiro.authc.AuthenticationToken AuthenticationToken}
+     *                and {@link org.apache.shiro.realm.Realm Realm}s to consult.
+     * @return an {@link Account} instance reflecting the authenticated identity, or {@code null} if no account could be returned.
+     * @throws AuthenticationException if there is an error during authentication.
+     */
+    Account execute(AuthenticationAttempt attempt) throws AuthenticationException;
+
+}

--- a/core/src/main/java/org/apache/shiro/authc/strategy/DefaultAuthenticationAttempt.java
+++ b/core/src/main/java/org/apache/shiro/authc/strategy/DefaultAuthenticationAttempt.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.authc.strategy;
+
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.realm.Realm;
+import org.apache.shiro.util.Assert;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * @since 2.0
+ */
+public class DefaultAuthenticationAttempt implements AuthenticationAttempt {
+
+    final AuthenticationToken authenticationToken;
+    final Collection<Realm> realms;
+
+    public DefaultAuthenticationAttempt(AuthenticationToken token, Collection<Realm> realms) {
+        Assert.notNull(token, "AuthenticationToken cannot be null.");
+        Assert.notEmpty(realms, "Realms collection cannot be null or empty.");
+        this.authenticationToken = token;
+        this.realms = Collections.unmodifiableCollection(realms);
+    }
+
+    public AuthenticationToken getAuthenticationToken() {
+        return this.authenticationToken;
+    }
+
+    public Collection<Realm> getRealms() {
+        return this.realms;
+    }
+}

--- a/core/src/main/java/org/apache/shiro/authc/strategy/FirstRealmSuccessfulStrategy.java
+++ b/core/src/main/java/org/apache/shiro/authc/strategy/FirstRealmSuccessfulStrategy.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.authc.strategy;
+
+import org.apache.shiro.account.Account;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.realm.Realm;
+import org.apache.shiro.util.CollectionUtils;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * The {@code FirstRealmSuccessfulStrategy} will iterate over the available realms and invoke
+ * {@code realm.}{@link Realm#authenticateAccount(org.apache.shiro.authc.AuthenticationToken) authenticateAccount(authenticationToken)}
+ * on each one; the first time a realm returns an {@code Account} without throwing an exception, that
+ * account is returned immediately, and all subsequent realms are ignored entirely (iteration 'short circuits').
+ * <p/>
+ * If no realms return an {@code Account}:
+ * <ul>
+ *     <li>If only one exception was thrown by any consulted Realm, that exception is thrown.</li>
+ *     <li>If more than one Realm threw an exception during consultation, those exceptions are bundled together as a
+ *         {@link MultiRealmAuthenticationException} and that exception is thrown.</li>
+ *     <li>If no exceptions were thrown, {@code null} is returned, indicating to the calling
+ *         {@link org.apache.shiro.authc.Authenticator Authenticator} that no account could be found.</li>
+ * </ul>
+ *
+ * @since 2.0
+ */
+public class FirstRealmSuccessfulStrategy implements AuthenticationStrategy {
+
+    public Account execute(AuthenticationAttempt attempt) throws AuthenticationException {
+
+        AuthenticationToken token = attempt.getAuthenticationToken();
+
+        Map<String, Throwable> realmErrors = new LinkedHashMap<String, Throwable>();
+
+        for(Realm realm : attempt.getRealms()) {
+
+            if (realm.supports(token)) {
+
+                Account account;
+
+                try {
+                    account = realm.authenticateAccount(token);
+                } catch (Throwable t) {
+
+                    //noinspection ThrowableResultOfMethodCallIgnored
+                    realmErrors.put(realm.getName(), t);
+
+                    //current realm failed - try the next one:
+                    continue;
+                }
+
+                if (account != null) {
+                    //successfully acquired an account - stop iterating, return immediately:
+                    return account;
+                }
+            }
+        }
+
+        if (!CollectionUtils.isEmpty(realmErrors)) {
+            if (realmErrors.size() == 1) {
+                Throwable t = realmErrors.values().iterator().next();
+                if (t instanceof AuthenticationException) {
+                    throw (AuthenticationException)t;
+                }
+                throw new AuthenticationException("Unable to authenticate realm account.", t);
+            } //else more than one throwable encountered:
+            throw new MultiRealmAuthenticationException(realmErrors);
+        }
+
+        return null;
+    }
+}

--- a/core/src/main/java/org/apache/shiro/authc/strategy/MultiRealmAuthenticationException.java
+++ b/core/src/main/java/org/apache/shiro/authc/strategy/MultiRealmAuthenticationException.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.authc.strategy;
+
+import org.apache.shiro.authc.AuthenticationException;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * @since 2.0
+ */
+public class MultiRealmAuthenticationException extends AuthenticationException {
+
+    private final Map<String, Throwable> realmErrors;
+
+    public MultiRealmAuthenticationException(Map<String, Throwable> realmErrors) {
+        super("Multiple authentication problems across various realms.  " +
+                "Only the first discovered exception will be shown as the cause; call getRealmExceptions() " +
+                "to access all of them.", realmErrors.values().iterator().next());
+        this.realmErrors = Collections.unmodifiableMap(realmErrors);
+    }
+
+    public Map<String, Throwable> getRealmExceptions() {
+        return this.realmErrors;
+    }
+}

--- a/core/src/main/java/org/apache/shiro/authc/strategy/package-info.java
+++ b/core/src/main/java/org/apache/shiro/authc/strategy/package-info.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Support for pluggable authentication strategy logic for applications configured with multiple realms.
+ * <p/>
+ * An {@link org.apache.shiro.authc.strategy.AuthenticationStrategy AuthenticationStrategy} implementation interacts
+ * with multiple realms during an authentication attempt and determines how the interactions translates to a successful
+ * or failed login attempt.
+ * <h3>How It Works</h3>
+ * When a Subject attempts to login to the application, the {@link org.apache.shiro.authc.Authenticator Authenticator}
+ * implementation (usually a {@link org.apache.shiro.authc.DefaultAuthenticator DefaultAuthenticator}) delegates the
+ * actual realm interaction logic to its configured {@code AuthenticationStrategy}.  The {@code AuthenticationStrategy}
+ * then interacts with the realms as necessary and determines the outcome of the attempt (success or failure).
+ * <p/>
+ * The {@link org.apache.shiro.authc.DefaultAuthenticator DefaultAuthenticator} implementation defaults to a
+ * {@link org.apache.shiro.authc.strategy.FirstRealmSuccessfulStrategy FirstRealmSuccessfulStrategy} as this appears to
+ * suit the needs of most Shiro users, but of course any of the other out-of-the-box Strategy implementations or a
+ * custom implementation may be configured if desired.
+ *
+ * @see org.apache.shiro.authc.strategy.AuthenticationStrategy AuthenticationStrategy
+ * @see org.apache.shiro.authc.strategy.FirstRealmSuccessfulStrategy FirstRealmSuccessfulStrategy
+ * @see org.apache.shiro.authc.strategy.AtLeastOneRealmSuccessfulStrategy AtLeastOneRealmSuccessfulStrategy
+ * @see org.apache.shiro.authc.strategy.AllRealmsSuccessfulStrategy AllRealmsSuccessfulStrategy
+ * @see org.apache.shiro.authc.DefaultAuthenticator DefaultAuthenticator
+ *
+ * @since 2.0
+ */
+package org.apache.shiro.authc.strategy;

--- a/core/src/main/java/org/apache/shiro/authz/AuthorizationInfo.java
+++ b/core/src/main/java/org/apache/shiro/authz/AuthorizationInfo.java
@@ -38,7 +38,7 @@ import java.util.Collection;
  * Both permission collections together represent the total aggregate collection of permissions.  You may use one
  * or both depending on your preference and needs.
  * <p/>
- * Because the act of authorization (access control) is orthoganal to authentication (log-in), this interface is
+ * Because the act of authorization (access control) is orthogonal to authentication (log-in), this interface is
  * intended to represent only the account data needed by Shiro during an access control check
  * (role, permission, etc).  Shiro also has a parallel
  * {@link org.apache.shiro.authc.AuthenticationInfo AuthenticationInfo} interface for use during the authentication

--- a/core/src/main/java/org/apache/shiro/authz/Authorizer.java
+++ b/core/src/main/java/org/apache/shiro/authz/Authorizer.java
@@ -54,7 +54,7 @@ public interface Authorizer {
      * <p>This is an overloaded method for the corresponding type-safe {@link Permission Permission} variant.
      * Please see the class-level JavaDoc for more information on these String-based permission methods.
      *
-     * @param principals the application-specific subject/user identifier.
+     * @param principals the application-specific subject/user identifier(s).
      * @param permission the String representation of a Permission that is being checked.
      * @return true if the corresponding Subject/user is permitted, false otherwise.
      * @see #isPermitted(PrincipalCollection principals,Permission permission)
@@ -69,11 +69,11 @@ public interface Authorizer {
      * <p>More specifically, this method determines if any <tt>Permission</tt>s associated
      * with the subject {@link Permission#implies(Permission) imply} the specified permission.
      *
-     * @param subjectPrincipal the application-specific subject/user identifier.
+     * @param principals the application-specific subject/user identifier(s).
      * @param permission       the permission that is being checked.
      * @return true if the corresponding Subject/user is permitted, false otherwise.
      */
-    boolean isPermitted(PrincipalCollection subjectPrincipal, Permission permission);
+    boolean isPermitted(PrincipalCollection principals, Permission permission);
 
     /**
      * Checks if the corresponding Subject implies the given permission strings and returns a boolean array
@@ -82,7 +82,7 @@ public interface Authorizer {
      * <p>This is an overloaded method for the corresponding type-safe {@link Permission Permission} variant.
      * Please see the class-level JavaDoc for more information on these String-based permission methods.
      *
-     * @param subjectPrincipal the application-specific subject/user identifier.
+     * @param principals the application-specific subject/user identifier(s).
      * @param permissions      the String representations of the Permissions that are being checked.
      * @return an array of booleans whose indices correspond to the index of the
      *         permissions in the given list.  A true value at an index indicates the user is permitted for
@@ -90,7 +90,7 @@ public interface Authorizer {
      *         indicates otherwise.
      * @since 0.9
      */
-    boolean[] isPermitted(PrincipalCollection subjectPrincipal, String... permissions);
+    boolean[] isPermitted(PrincipalCollection principals, String... permissions);
 
     /**
      * Checks if the corresponding Subject/user implies the given Permissions and returns a boolean array indicating
@@ -103,14 +103,14 @@ public interface Authorizer {
      * <p>This is primarily a performance-enhancing method to help reduce the number of
      * {@link #isPermitted} invocations over the wire in client/server systems.
      *
-     * @param subjectPrincipal the application-specific subject/user identifier.
+     * @param principals the application-specific subject/user identifier(s).
      * @param permissions      the permissions that are being checked.
      * @return an array of booleans whose indices correspond to the index of the
      *         permissions in the given list.  A true value at an index indicates the user is permitted for
      *         for the associated <tt>Permission</tt> object in the list.  A false value at an index
      *         indicates otherwise.
      */
-    boolean[] isPermitted(PrincipalCollection subjectPrincipal, List<Permission> permissions);
+    boolean[] isPermitted(PrincipalCollection principals, List<Permission> permissions);
 
     /**
      * Returns <tt>true</tt> if the corresponding Subject/user implies all of the specified permission strings,
@@ -119,13 +119,13 @@ public interface Authorizer {
      * <p>This is an overloaded method for the corresponding type-safe {@link Permission Permission} variant.
      * Please see the class-level JavaDoc for more information on these String-based permission methods.
      *
-     * @param subjectPrincipal the application-specific subject/user identifier.
+     * @param principals the application-specific subject/user identifier(s).
      * @param permissions      the String representations of the Permissions that are being checked.
      * @return true if the user has all of the specified permissions, false otherwise.
      * @see #isPermittedAll(PrincipalCollection,Collection)
      * @since 0.9
      */
-    boolean isPermittedAll(PrincipalCollection subjectPrincipal, String... permissions);
+    boolean isPermittedAll(PrincipalCollection principals, String... permissions);
 
     /**
      * Returns <tt>true</tt> if the corresponding Subject/user implies all of the specified permissions, <tt>false</tt>
@@ -134,11 +134,11 @@ public interface Authorizer {
      * <p>More specifically, this method determines if all of the given <tt>Permission</tt>s are
      * {@link Permission#implies(Permission) implied by} permissions already associated with the subject.
      *
-     * @param subjectPrincipal the application-specific subject/user identifier.
+     * @param principals the application-specific subject/user identifier(s).
      * @param permissions      the permissions to check.
      * @return true if the user has all of the specified permissions, false otherwise.
      */
-    boolean isPermittedAll(PrincipalCollection subjectPrincipal, Collection<Permission> permissions);
+    boolean isPermittedAll(PrincipalCollection principals, Collection<Permission> permissions);
 
     /**
      * Ensures the corresponding Subject/user implies the specified permission String.
@@ -149,44 +149,44 @@ public interface Authorizer {
      * <p>This is an overloaded method for the corresponding type-safe {@link Permission Permission} variant.
      * Please see the class-level JavaDoc for more information on these String-based permission methods.
      *
-     * @param subjectPrincipal the application-specific subject/user identifier.
+     * @param principals the application-specific subject/user identifier(s).
      * @param permission       the String representation of the Permission to check.
      * @throws AuthorizationException
      *          if the user does not have the permission.
      * @since 0.9
      */
-    void checkPermission(PrincipalCollection subjectPrincipal, String permission) throws AuthorizationException;
+    void checkPermission(PrincipalCollection principals, String permission) throws AuthorizationException;
 
     /**
      * Ensures a subject/user {@link Permission#implies(Permission)} implies} the specified <tt>Permission</tt>.
      * If the subject's exisiting associated permissions do not {@link Permission#implies(Permission)} imply}
      * the given permission, an {@link AuthorizationException} will be thrown.
      *
-     * @param subjectPrincipal the application-specific subject/user identifier.
+     * @param principals the application-specific subject/user identifier(s).
      * @param permission       the Permission to check.
      * @throws AuthorizationException
      *          if the user does not have the permission.
      */
-    void checkPermission(PrincipalCollection subjectPrincipal, Permission permission) throws AuthorizationException;
+    void checkPermission(PrincipalCollection principals, Permission permission) throws AuthorizationException;
 
     /**
      * Ensures the corresponding Subject/user
      * {@link Permission#implies(Permission) implies} all of the
      * specified permission strings.
      *
-     * If the subject's exisiting associated permissions do not
+     * If the subject's existing associated permissions do not
      * {@link Permission#implies(Permission) imply} all of the given permissions,
      * an {@link AuthorizationException} will be thrown.
      *
      * <p>This is an overloaded method for the corresponding type-safe {@link Permission Permission} variant.
      * Please see the class-level JavaDoc for more information on these String-based permission methods.
      *
-     * @param subjectPrincipal the application-specific subject/user identifier.
+     * @param principals the application-specific subject/user identifier(s).
      * @param permissions      the string representations of Permissions to check.
      * @throws AuthorizationException if the user does not have all of the given permissions.
      * @since 0.9
      */
-    void checkPermissions(PrincipalCollection subjectPrincipal, String... permissions) throws AuthorizationException;
+    void checkPermissions(PrincipalCollection principals, String... permissions) throws AuthorizationException;
 
     /**
      * Ensures the corresponding Subject/user
@@ -197,20 +197,20 @@ public interface Authorizer {
      * {@link Permission#implies(Permission) imply} all of the given permissions,
      * an {@link AuthorizationException} will be thrown.
      *
-     * @param subjectPrincipal the application-specific subject/user identifier.
+     * @param principals the application-specific subject/user identifier(s).
      * @param permissions      the Permissions to check.
      * @throws AuthorizationException if the user does not have all of the given permissions.
      */
-    void checkPermissions(PrincipalCollection subjectPrincipal, Collection<Permission> permissions) throws AuthorizationException;
+    void checkPermissions(PrincipalCollection principals, Collection<Permission> permissions) throws AuthorizationException;
 
     /**
      * Returns <tt>true</tt> if the corresponding Subject/user has the specified role, <tt>false</tt> otherwise.
      *
-     * @param subjectPrincipal the application-specific subject/user identifier.
+     * @param principals the application-specific subject/user identifier(s).
      * @param roleIdentifier   the application-specific role identifier (usually a role id or role name).
      * @return <tt>true</tt> if the corresponding subject has the specified role, <tt>false</tt> otherwise.
      */
-    boolean hasRole(PrincipalCollection subjectPrincipal, String roleIdentifier);
+    boolean hasRole(PrincipalCollection principals, String roleIdentifier);
 
     /**
      * Checks if the corresponding Subject/user has the specified roles, returning a boolean array indicating
@@ -219,60 +219,60 @@ public interface Authorizer {
      * <p>This is primarily a performance-enhancing method to help reduce the number of
      * {@link #hasRole} invocations over the wire in client/server systems.
      *
-     * @param subjectPrincipal the application-specific subject/user identifier.
+     * @param principals the application-specific subject/user identifier(s).
      * @param roleIdentifiers  the application-specific role identifiers to check (usually role ids or role names).
      * @return an array of booleans whose indices correspond to the index of the
      *         roles in the given identifiers.  A true value indicates the user has the
      *         role at that index.  False indicates the user does not have the role at that index.
      */
-    boolean[] hasRoles(PrincipalCollection subjectPrincipal, List<String> roleIdentifiers);
+    boolean[] hasRoles(PrincipalCollection principals, List<String> roleIdentifiers);
 
     /**
      * Returns <tt>true</tt> if the corresponding Subject/user has all of the specified roles, <tt>false</tt> otherwise.
      *
-     * @param subjectPrincipal the application-specific subject/user identifier.
+     * @param principals the application-specific subject/user identifier(s).
      * @param roleIdentifiers  the application-specific role identifiers to check (usually role ids or role names).
      * @return true if the user has all the roles, false otherwise.
      */
-    boolean hasAllRoles(PrincipalCollection subjectPrincipal, Collection<String> roleIdentifiers);
+    boolean hasAllRoles(PrincipalCollection principals, Collection<String> roleIdentifiers);
 
     /**
      * Asserts the corresponding Subject/user has the specified role by returning quietly if they do or throwing an
      * {@link AuthorizationException} if they do not.
      *
-     * @param subjectPrincipal the application-specific subject/user identifier.
+     * @param principals the application-specific subject/user identifier(s).
      * @param roleIdentifier   the application-specific role identifier (usually a role id or role name ).
      * @throws AuthorizationException
      *          if the user does not have the role.
      */
-    void checkRole(PrincipalCollection subjectPrincipal, String roleIdentifier) throws AuthorizationException;
+    void checkRole(PrincipalCollection principals, String roleIdentifier) throws AuthorizationException;
 
     /**
      * Asserts the corresponding Subject/user has all of the specified roles by returning quietly if they do or
      * throwing an {@link AuthorizationException} if they do not.
      *
-     * @param subjectPrincipal the application-specific subject/user identifier.
+     * @param principals the application-specific subject/user identifier(s).
      * @param roleIdentifiers  the application-specific role identifiers to check (usually role ids or role names).
      * @throws AuthorizationException
      *          if the user does not have all of the specified roles.
      */
-    void checkRoles(PrincipalCollection subjectPrincipal, Collection<String> roleIdentifiers) throws AuthorizationException;
+    void checkRoles(PrincipalCollection principals, Collection<String> roleIdentifiers) throws AuthorizationException;
 
     /**
      * Same as {@link #checkRoles(org.apache.shiro.subject.PrincipalCollection, java.util.Collection)
-     * checkRoles(PrincipalCollection subjectPrincipal, Collection&lt;String&gt; roleIdentifiers)} but doesn't require a collection
+     * checkRoles(PrincipalCollection principals, Collection&lt;String&gt; roleIdentifiers)} but doesn't require a collection
      * as an argument.
      * Asserts the corresponding Subject/user has all of the specified roles by returning quietly if they do or
      * throwing an {@link AuthorizationException} if they do not.
      *
-     * @param subjectPrincipal the application-specific subject/user identifier.
+     * @param principals the application-specific subject/user identifier(s).
      * @param roleIdentifiers  the application-specific role identifiers to check (usually role ids or role names).
      * @throws AuthorizationException
      *          if the user does not have all of the specified roles.
      *          
      *  @since 1.1.0
      */
-    void checkRoles(PrincipalCollection subjectPrincipal, String... roleIdentifiers) throws AuthorizationException;
+    void checkRoles(PrincipalCollection principals, String... roleIdentifiers) throws AuthorizationException;
     
 }
 

--- a/core/src/main/java/org/apache/shiro/mgt/ApplicationSecurityManager.java
+++ b/core/src/main/java/org/apache/shiro/mgt/ApplicationSecurityManager.java
@@ -1,0 +1,810 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.mgt;
+
+import org.apache.shiro.account.Account;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.Authenticator;
+import org.apache.shiro.authc.DefaultAuthenticator;
+import org.apache.shiro.authc.LogoutAware;
+import org.apache.shiro.authz.AuthorizationException;
+import org.apache.shiro.authz.Authorizer;
+import org.apache.shiro.authz.ModularRealmAuthorizer;
+import org.apache.shiro.authz.Permission;
+import org.apache.shiro.cache.CacheManager;
+import org.apache.shiro.cache.CacheManagerAware;
+import org.apache.shiro.cache.DisabledCacheManager;
+import org.apache.shiro.event.EventBus;
+import org.apache.shiro.event.EventBusAware;
+import org.apache.shiro.event.support.DefaultEventBus;
+import org.apache.shiro.realm.Realm;
+import org.apache.shiro.session.InvalidSessionException;
+import org.apache.shiro.session.Session;
+import org.apache.shiro.session.SessionException;
+import org.apache.shiro.session.mgt.DefaultSessionContext;
+import org.apache.shiro.session.mgt.DefaultSessionKey;
+import org.apache.shiro.session.mgt.SessionContext;
+import org.apache.shiro.session.mgt.SessionKey;
+import org.apache.shiro.session.mgt.SessionManager;
+import org.apache.shiro.subject.PrincipalCollection;
+import org.apache.shiro.subject.Subject;
+import org.apache.shiro.subject.SubjectContext;
+import org.apache.shiro.subject.support.DefaultSubjectContext;
+import org.apache.shiro.util.Assert;
+import org.apache.shiro.util.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/** @since 2.0 */
+public class ApplicationSecurityManager implements SecurityManager, EventBusAware, CacheManagerAware {
+
+    private static final Logger log = LoggerFactory.getLogger(ApplicationSecurityManager.class);
+
+    /** The EventBus to use to use to publish and receive events of interest during Shiro's operation.  Never null. */
+    private EventBus eventBus;
+
+    /**
+     * The CacheManager to use to perform caching operations to enhance performance.
+     * Cannot be null - to disable caching, a DisabledCacheManager should be configured (the default).
+     */
+    private CacheManager cacheManager;
+
+    private Collection<Realm> realms;
+
+    private Authenticator  authenticator;
+    private Authorizer     authorizer;
+    private SessionManager sessionManager;
+
+    private RememberMeManager rememberMeManager;
+    private SubjectDAO        subjectDAO;
+    private SubjectFactory    subjectFactory;
+
+    public ApplicationSecurityManager() {
+        this.eventBus = new DefaultEventBus();
+        setCacheManager(new DisabledCacheManager());
+
+        // ===== Authenticator =====
+        DefaultAuthenticator authenticator = new DefaultAuthenticator();
+        authenticator.setEventBus(this.eventBus);
+        setAuthenticator(authenticator);
+
+        // ===== Authorizer =====
+        setAuthorizer(new ModularRealmAuthorizer());
+    }
+
+    /* ===================================================================== *
+     * Getters and Setters                                                   *
+     * ===================================================================== */
+
+    private Set<Object> getDependenciesForInjection(Object ignore) {
+        Set<Object> deps = CollectionUtils.asSet(
+            eventBus, cacheManager, realms, authenticator, authorizer, sessionManager,
+            rememberMeManager, subjectDAO, subjectFactory
+        );
+        if (ignore != null) {
+            deps.remove(ignore);
+        }
+        return deps;
+    }
+
+    public Collection<Realm> getRealms() {
+        return realms;
+    }
+
+    public void setRealms(Collection<Realm> realms) {
+        Assert.notEmpty(realms, "Realms argument cannot be empty.");
+        Collection<Realm> immutableRealmsCollection = Collections.unmodifiableCollection(realms);
+        this.realms = immutableRealmsCollection;
+        applyEventBus(this.realms);
+        applyCacheManager(this.realms);
+        Authenticator authc = this.authenticator;
+        if (authc instanceof DefaultAuthenticator) {
+            ((DefaultAuthenticator) authc).setRealms(immutableRealmsCollection);
+        }
+        Authorizer authz = this.authorizer;
+        if (authz instanceof ModularRealmAuthorizer) {
+            ((ModularRealmAuthorizer) authz).setRealms(immutableRealmsCollection);
+        }
+    }
+
+    public EventBus getEventBus() {
+        return eventBus;
+    }
+
+    public void setEventBus(EventBus eventBus) {
+        Assert.notNull(eventBus, "EventBus argument cannot be null.");
+        this.eventBus = eventBus;
+        applyEventBus(getDependenciesForInjection(this.eventBus));
+    }
+
+    private void applyEventBus(Object target) {
+        if (target instanceof Collection) {
+            Collection c = (Collection) target;
+            for (Object o : c) {
+                applyEventBus(o);
+            }
+        }
+        if (target instanceof EventBusAware) {
+            ((EventBusAware) target).setEventBus(this.eventBus);
+        }
+    }
+
+    public CacheManager getCacheManager() {
+        return cacheManager;
+    }
+
+    public void setCacheManager(CacheManager cacheManager) {
+        Assert.notNull(cacheManager, "CacheManager cannot be null.  If you want to disable caching, configure a " +
+                                     DisabledCacheManager.class.getName() + " instance.");
+        this.cacheManager = cacheManager;
+        applyCacheManager(getDependenciesForInjection(this.cacheManager));
+    }
+
+    private void applyCacheManager(Object target) {
+        if (target instanceof Collection) {
+            Collection c = (Collection) target;
+            for (Object o : c) {
+                applyCacheManager(o);
+            }
+        }
+        if (target instanceof CacheManagerAware) {
+            ((CacheManagerAware) target).setCacheManager(this.cacheManager);
+        }
+    }
+
+    public Authenticator getAuthenticator() {
+        return authenticator;
+    }
+
+    public void setAuthenticator(Authenticator authenticator) {
+        Assert.notNull(authenticator, "Authenticator argument cannot be null.");
+        this.authenticator = authenticator;
+        if (this.authenticator instanceof DefaultAuthenticator) {
+            ((DefaultAuthenticator) this.authenticator).setRealms(this.realms);
+        }
+        applyEventBus(this.authenticator);
+        applyCacheManager(this.authenticator);
+    }
+
+    public Authorizer getAuthorizer() {
+        return authorizer;
+    }
+
+    public void setAuthorizer(Authorizer authorizer) {
+        Assert.notNull(authorizer, "Authorizer argument cannot be null.");
+        this.authorizer = authorizer;
+        applyEventBus(this.authorizer);
+        applyCacheManager(this.authorizer);
+    }
+
+    public SessionManager getSessionManager() {
+        return sessionManager;
+    }
+
+    public void setSessionManager(SessionManager sessionManager) {
+        this.sessionManager = sessionManager;
+    }
+
+    /**
+     * Returns the {@code SubjectFactory} responsible for creating {@link Subject} instances exposed to the
+     * application.
+     *
+     * @return the {@code SubjectFactory} responsible for creating {@link Subject} instances exposed to the
+     *         application.
+     */
+    public SubjectFactory getSubjectFactory() {
+        return subjectFactory;
+    }
+
+    /**
+     * Sets the {@code SubjectFactory} responsible for creating {@link Subject} instances exposed to the application.
+     *
+     * @param subjectFactory the {@code SubjectFactory} responsible for creating {@link Subject} instances exposed to
+     *                       the application.
+     */
+    public void setSubjectFactory(SubjectFactory subjectFactory) {
+        this.subjectFactory = subjectFactory;
+    }
+
+    /**
+     * Returns the {@code SubjectDAO} responsible for persisting Subject state, typically used after login or when an
+     * Subject identity is discovered (eg after RememberMe services).  Unless configured otherwise, the default
+     * implementation is a {@link DefaultSubjectDAO}.
+     *
+     * @return the {@code SubjectDAO} responsible for persisting Subject state, typically used after login or when an
+     *         Subject identity is discovered (eg after RememberMe services).
+     * @see DefaultSubjectDAO
+     */
+    public SubjectDAO getSubjectDAO() {
+        return subjectDAO;
+    }
+
+    /**
+     * Sets the {@code SubjectDAO} responsible for persisting Subject state, typically used after login or when an
+     * Subject identity is discovered (eg after RememberMe services). Unless configured otherwise, the default
+     * implementation is a {@link DefaultSubjectDAO}.
+     *
+     * @param subjectDAO the {@code SubjectDAO} responsible for persisting Subject state, typically used after login or
+     *                   when an
+     *                   Subject identity is discovered (eg after RememberMe services).
+     * @see DefaultSubjectDAO
+     */
+    public void setSubjectDAO(SubjectDAO subjectDAO) {
+        this.subjectDAO = subjectDAO;
+    }
+
+    public RememberMeManager getRememberMeManager() {
+        return rememberMeManager;
+    }
+
+    public void setRememberMeManager(RememberMeManager rememberMeManager) {
+        this.rememberMeManager = rememberMeManager;
+    }
+
+    /* ===================================================================== *
+     * Authenticator Methods                                                 *
+     * ===================================================================== */
+
+    public AuthenticationInfo authenticate(AuthenticationToken authenticationToken) throws AuthenticationException {
+        return this.authenticator.authenticate(authenticationToken);
+    }
+
+    public Account authenticateAccount(AuthenticationToken authenticationToken) throws AuthenticationException {
+        return this.authenticator.authenticateAccount(authenticationToken);
+    }
+
+    /* ===================================================================== *
+     * Authorizer Methods                                                    *
+     * ===================================================================== */
+
+    public boolean isPermitted(PrincipalCollection principals, String permission) {
+        return this.authorizer.isPermitted(principals, permission);
+    }
+
+    public boolean isPermitted(PrincipalCollection principals, Permission permission) {
+        return this.authorizer.isPermitted(principals, permission);
+    }
+
+    public boolean[] isPermitted(PrincipalCollection principals, String... permissions) {
+        return this.authorizer.isPermitted(principals, permissions);
+    }
+
+    public boolean[] isPermitted(PrincipalCollection principals, List<Permission> permissions) {
+        return this.authorizer.isPermitted(principals, permissions);
+    }
+
+    public boolean isPermittedAll(PrincipalCollection principals, String... permissions) {
+        return this.authorizer.isPermittedAll(principals, permissions);
+    }
+
+    public boolean isPermittedAll(PrincipalCollection principals, Collection<Permission> permissions) {
+        return this.authorizer.isPermittedAll(principals, permissions);
+    }
+
+    public void checkPermission(PrincipalCollection principals, String permission) throws AuthorizationException {
+        this.authorizer.checkPermission(principals, permission);
+    }
+
+    public void checkPermission(PrincipalCollection principals, Permission permission) throws AuthorizationException {
+        this.authorizer.checkPermission(principals, permission);
+    }
+
+    public void checkPermissions(PrincipalCollection principals, String... permissions) throws AuthorizationException {
+        this.authorizer.checkPermissions(principals, permissions);
+    }
+
+    public void checkPermissions(PrincipalCollection principals, Collection<Permission> permissions)
+        throws AuthorizationException {
+        this.authorizer.checkPermissions(principals, permissions);
+    }
+
+    public boolean hasRole(PrincipalCollection principals, String roleIdentifier) {
+        return this.authorizer.hasRole(principals, roleIdentifier);
+    }
+
+    public boolean[] hasRoles(PrincipalCollection principals, List<String> roleIdentifiers) {
+        return this.authorizer.hasRoles(principals, roleIdentifiers);
+    }
+
+    public boolean hasAllRoles(PrincipalCollection principals, Collection<String> roleIdentifiers) {
+        return this.authorizer.hasAllRoles(principals, roleIdentifiers);
+    }
+
+    public void checkRole(PrincipalCollection principals, String roleIdentifier) throws AuthorizationException {
+        this.authorizer.checkRole(principals, roleIdentifier);
+    }
+
+    public void checkRoles(PrincipalCollection principals, Collection<String> roleIdentifiers)
+        throws AuthorizationException {
+        this.authorizer.checkRoles(principals, roleIdentifiers);
+    }
+
+    public void checkRoles(PrincipalCollection principals, String... roleIdentifiers)
+        throws AuthorizationException {
+        this.authorizer.checkRoles(principals, roleIdentifiers);
+    }
+
+    /* ===================================================================== *
+     * SessionManager Methods                                                *
+     * ===================================================================== */
+
+    public Session start(SessionContext context) {
+        return this.sessionManager.start(context);
+    }
+
+    public Session getSession(SessionKey key) throws SessionException {
+        return this.sessionManager.getSession(key);
+    }
+
+    /* ===================================================================== *
+     * SecurityManager Methods                                               *
+     * ===================================================================== */
+
+    protected SubjectContext createSubjectContext() {
+        return new DefaultSubjectContext();
+    }
+
+    /**
+     * Creates a {@code Subject} instance for the user represented by the given method arguments.
+     *
+     * @param token    the {@code AuthenticationToken} submitted for the successful authentication.
+     * @param info     the {@code AuthenticationInfo} of a newly authenticated user.
+     * @param existing the existing {@code Subject} instance that initiated the authentication attempt
+     * @return the {@code Subject} instance that represents the context and session data for the newly
+     *         authenticated subject.
+     */
+    protected Subject createSubject(AuthenticationToken token, AuthenticationInfo info, Subject existing) {
+        SubjectContext context = createSubjectContext();
+        context.setAuthenticated(true);
+        context.setAuthenticationToken(token);
+        context.setAuthenticationInfo(info);
+        if (existing != null) {
+            context.setSubject(existing);
+        }
+        return createSubject(context);
+    }
+
+    /**
+     * Binds a {@code Subject} instance created after authentication to the application for later use.
+     * <p/>
+     * As of Shiro 1.2, this method has been deprecated in favor of {@link #save(org.apache.shiro.subject.Subject)},
+     * which this implementation now calls.
+     *
+     * @param subject the {@code Subject} instance created after authentication to be bound to the application
+     *                for later use.
+     * @see #save(org.apache.shiro.subject.Subject)
+     * @deprecated in favor of {@link #save(org.apache.shiro.subject.Subject) save(subject)}.
+     */
+    @Deprecated
+    protected void bind(Subject subject) {
+        save(subject);
+    }
+
+    protected void rememberMeSuccessfulLogin(AuthenticationToken token, AuthenticationInfo info, Subject subject) {
+        RememberMeManager rmm = getRememberMeManager();
+        if (rmm != null) {
+            try {
+                rmm.onSuccessfulLogin(subject, token, info);
+            } catch (Exception e) {
+                if (log.isWarnEnabled()) {
+                    String msg = "Delegate RememberMeManager instance of type [" + rmm.getClass().getName() +
+                                 "] threw an exception during onSuccessfulLogin.  RememberMe services will not be " +
+                                 "performed for account [" + info + "].";
+                    log.warn(msg, e);
+                }
+            }
+        } else {
+            if (log.isTraceEnabled()) {
+                log.trace("This " + getClass().getName() + " instance does not have a " +
+                          "[" + RememberMeManager.class.getName() + "] instance configured.  RememberMe services " +
+                          "will not be performed for account [" + info + "].");
+            }
+        }
+    }
+
+    protected void rememberMeFailedLogin(AuthenticationToken token, AuthenticationException ex, Subject subject) {
+        RememberMeManager rmm = getRememberMeManager();
+        if (rmm != null) {
+            try {
+                rmm.onFailedLogin(subject, token, ex);
+            } catch (Exception e) {
+                if (log.isWarnEnabled()) {
+                    String msg = "Delegate RememberMeManager instance of type [" + rmm.getClass().getName() +
+                                 "] threw an exception during onFailedLogin for AuthenticationToken [" +
+                                 token + "].";
+                    log.warn(msg, e);
+                }
+            }
+        }
+    }
+
+    protected void rememberMeLogout(Subject subject) {
+        RememberMeManager rmm = getRememberMeManager();
+        if (rmm != null) {
+            try {
+                rmm.onLogout(subject);
+            } catch (Exception e) {
+                if (log.isWarnEnabled()) {
+                    String msg = "Delegate RememberMeManager instance of type [" + rmm.getClass().getName() +
+                                 "] threw an exception during onLogout for subject with principals [" +
+                                 (subject != null ? subject.getPrincipals() : null) + "]";
+                    log.warn(msg, e);
+                }
+            }
+        }
+    }
+
+    /**
+     * First authenticates the {@code AuthenticationToken} argument, and if successful, constructs a
+     * {@code Subject} instance representing the authenticated account's identity.
+     * <p/>
+     * Once constructed, the {@code Subject} instance is then {@link #bind bound} to the application for
+     * subsequent access before being returned to the caller.
+     *
+     * @param token the authenticationToken to process for the login attempt.
+     * @return a Subject representing the authenticated user.
+     * @throws AuthenticationException if there is a problem authenticating the specified {@code token}.
+     */
+    public Subject login(Subject subject, AuthenticationToken token) throws AuthenticationException {
+        AuthenticationInfo info;
+        try {
+            info = authenticate(token);
+        } catch (AuthenticationException ae) {
+            try {
+                onFailedLogin(token, ae, subject);
+            } catch (Exception e) {
+                if (log.isInfoEnabled()) {
+                    log.info("onFailedLogin method threw an " +
+                             "exception.  Logging and propagating original AuthenticationException.", e);
+                }
+            }
+            throw ae; //propagate
+        }
+
+        Subject loggedIn = createSubject(token, info, subject);
+
+        onSuccessfulLogin(token, info, loggedIn);
+
+        return loggedIn;
+    }
+
+    protected void onSuccessfulLogin(AuthenticationToken token, AuthenticationInfo info, Subject subject) {
+        rememberMeSuccessfulLogin(token, info, subject);
+    }
+
+    protected void onFailedLogin(AuthenticationToken token, AuthenticationException ae, Subject subject) {
+        rememberMeFailedLogin(token, ae, subject);
+    }
+
+    protected void beforeLogout(Subject subject) {
+        rememberMeLogout(subject);
+    }
+
+    protected SubjectContext copy(SubjectContext subjectContext) {
+        return new DefaultSubjectContext(subjectContext);
+    }
+
+    /**
+     * This implementation functions as follows:
+     * <p/>
+     * <ol>
+     * <li>Ensures the {@code SubjectContext} is as populated as it can be, using heuristics to acquire
+     * data that may not have already been available to it (such as a referenced session or remembered
+     * principals).</li>
+     * <li>Calls {@link #doCreateSubject(org.apache.shiro.subject.SubjectContext)} to actually perform the
+     * {@code Subject} instance creation.</li>
+     * <li>calls {@link #save(org.apache.shiro.subject.Subject) save(subject)} to ensure the constructed
+     * {@code Subject}'s state is accessible for future requests/invocations if necessary.</li>
+     * <li>returns the constructed {@code Subject} instance.</li>
+     * </ol>
+     *
+     * @param subjectContext any data needed to direct how the Subject should be constructed.
+     * @return the {@code Subject} instance reflecting the specified contextual data.
+     * @see #ensureSecurityManager(org.apache.shiro.subject.SubjectContext)
+     * @see #resolveSession(org.apache.shiro.subject.SubjectContext)
+     * @see #resolvePrincipals(org.apache.shiro.subject.SubjectContext)
+     * @see #doCreateSubject(org.apache.shiro.subject.SubjectContext)
+     * @see #save(org.apache.shiro.subject.Subject)
+     * @since 1.0
+     */
+    public Subject createSubject(SubjectContext subjectContext) {
+        //create a copy so we don't modify the argument's backing map:
+        SubjectContext context = copy(subjectContext);
+
+        //ensure that the context has a SecurityManager instance, and if not, add one:
+        context = ensureSecurityManager(context);
+
+        //Resolve an associated Session (usually based on a referenced session ID), and place it in the context before
+        //sending to the SubjectFactory.  The SubjectFactory should not need to know how to acquire sessions as the
+        //process is often environment specific - better to shield the SF from these details:
+        context = resolveSession(context);
+
+        //Similarly, the SubjectFactory should not require any concept of RememberMe - translate that here first
+        //if possible before handing off to the SubjectFactory:
+        context = resolvePrincipals(context);
+
+        Subject subject = doCreateSubject(context);
+
+        //save this subject for future reference if necessary:
+        //(this is needed here in case rememberMe principals were resolved and they need to be stored in the
+        //session, so we don't constantly rehydrate the rememberMe PrincipalCollection on every operation).
+        //Added in 1.2:
+        save(subject);
+
+        return subject;
+    }
+
+    /**
+     * Actually creates a {@code Subject} instance by delegating to the internal
+     * {@link #getSubjectFactory() subjectFactory}.  By the time this method is invoked, all possible
+     * {@code SubjectContext} data (session, principals, et. al.) has been made accessible using all known heuristics
+     * and will be accessible to the {@code subjectFactory} via the {@code subjectContext.resolve*} methods.
+     *
+     * @param context the populated context (data map) to be used by the {@code SubjectFactory} when creating a
+     *                {@code Subject} instance.
+     * @return a {@code Subject} instance reflecting the data in the specified {@code SubjectContext} data map.
+     * @see #getSubjectFactory()
+     * @see SubjectFactory#createSubject(org.apache.shiro.subject.SubjectContext)
+     * @since 1.2
+     */
+    protected Subject doCreateSubject(SubjectContext context) {
+        return getSubjectFactory().createSubject(context);
+    }
+
+    /**
+     * Saves the subject's state to a persistent location for future reference if necessary.
+     * <p/>
+     * This implementation merely delegates to the internal {@link #setSubjectDAO(SubjectDAO) subjectDAO} and calls
+     * {@link SubjectDAO#save(org.apache.shiro.subject.Subject) subjectDAO.save(subject)}.
+     *
+     * @param subject the subject for which state will potentially be persisted
+     * @see SubjectDAO#save(org.apache.shiro.subject.Subject)
+     * @since 1.2
+     */
+    protected void save(Subject subject) {
+        this.subjectDAO.save(subject);
+    }
+
+    /**
+     * Removes (or 'unbinds') the Subject's state from the application, typically called during {@link #logout}..
+     * <p/>
+     * This implementation merely delegates to the internal {@link #setSubjectDAO(SubjectDAO) subjectDAO} and calls
+     * {@link SubjectDAO#delete(org.apache.shiro.subject.Subject) delete(subject)}.
+     *
+     * @param subject the subject for which state will be removed
+     * @see SubjectDAO#delete(org.apache.shiro.subject.Subject)
+     * @since 1.2
+     */
+    protected void delete(Subject subject) {
+        this.subjectDAO.delete(subject);
+    }
+
+    /**
+     * Determines if there is a {@code SecurityManager} instance in the context, and if not, adds 'this' to the
+     * context.  This ensures the SubjectFactory instance will have access to a SecurityManager during Subject
+     * construction if necessary.
+     *
+     * @param context the subject context data that may contain a SecurityManager instance.
+     * @return The SubjectContext to use to pass to a {@link SubjectFactory} for subject creation.
+     * @since 1.0
+     */
+    @SuppressWarnings({"unchecked"})
+    protected SubjectContext ensureSecurityManager(SubjectContext context) {
+        if (context.resolveSecurityManager() != null) {
+            log.trace("Context already contains a SecurityManager instance.  Returning.");
+            return context;
+        }
+        log.trace("No SecurityManager found in context.  Adding self reference.");
+        context.setSecurityManager(this);
+        return context;
+    }
+
+    /**
+     * Attempts to resolve any associated session based on the context and returns a
+     * context that represents this resolved {@code Session} to ensure it may be referenced if necessary by the
+     * invoked {@link SubjectFactory} that performs actual {@link Subject} construction.
+     * <p/>
+     * If there is a {@code Session} already in the context because that is what the caller wants to be used for
+     * {@code Subject} construction, or if no session is resolved, this method effectively does nothing
+     * returns the context method argument unaltered.
+     *
+     * @param context the subject context data that may resolve a Session instance.
+     * @return The context to use to pass to a {@link SubjectFactory} for subject creation.
+     * @since 1.0
+     */
+    @SuppressWarnings({"unchecked"})
+    protected SubjectContext resolveSession(SubjectContext context) {
+        if (context.resolveSession() != null) {
+            log.debug("Context already contains a session.  Returning.");
+            return context;
+        }
+        try {
+            //Context couldn't resolve it directly, let's see if we can since we have direct access to
+            //the session manager:
+            Session session = resolveContextSession(context);
+            if (session != null) {
+                context.setSession(session);
+            }
+        } catch (InvalidSessionException e) {
+            log.debug("Resolved SubjectContext context session is invalid.  Ignoring and creating an anonymous " +
+                      "(session-less) Subject instance.", e);
+        }
+        return context;
+    }
+
+    protected Session resolveContextSession(SubjectContext context) throws InvalidSessionException {
+        SessionKey key = getSessionKey(context);
+        if (key != null) {
+            return getSession(key);
+        }
+        return null;
+    }
+
+    protected SessionKey getSessionKey(SubjectContext context) {
+        Serializable sessionId = context.getSessionId();
+        if (sessionId != null) {
+            return new DefaultSessionKey(sessionId);
+        }
+        return null;
+    }
+
+    private static boolean isEmpty(PrincipalCollection pc) {
+        return pc == null || pc.isEmpty();
+    }
+
+    /**
+     * Attempts to resolve an identity (a {@link PrincipalCollection}) for the context using heuristics.  This
+     * implementation functions as follows:
+     * <ol>
+     * <li>Check the context to see if it can already {@link SubjectContext#resolvePrincipals resolve an identity}.  If
+     * so, this method does nothing and returns the method argument unaltered.</li>
+     * <li>Check for a RememberMe identity by calling {@link #getRememberedIdentity}.  If that method returns a
+     * non-null value, place the remembered {@link PrincipalCollection} in the context.</li>
+     * </ol>
+     *
+     * @param context the subject context data that may provide (directly or indirectly through one of its values) a
+     *                {@link PrincipalCollection} identity.
+     * @return The Subject context to use to pass to a {@link SubjectFactory} for subject creation.
+     * @since 1.0
+     */
+    @SuppressWarnings({"unchecked"})
+    protected SubjectContext resolvePrincipals(SubjectContext context) {
+
+        PrincipalCollection principals = context.resolvePrincipals();
+
+        if (isEmpty(principals)) {
+            log.trace("No identity (PrincipalCollection) found in the context.  Looking for a remembered identity.");
+
+            principals = getRememberedIdentity(context);
+
+            if (!isEmpty(principals)) {
+                log.debug("Found remembered PrincipalCollection.  Adding to the context to be used " +
+                          "for subject construction by the SubjectFactory.");
+
+                context.setPrincipals(principals);
+
+                // The following call was removed (commented out) in Shiro 1.2 because it uses the session as an
+                // implementation strategy.  Session use for Shiro's own needs should be controlled in a single place
+                // to be more manageable for end-users: there are a number of stateless (e.g. REST) applications that
+                // use Shiro that need to ensure that sessions are only used when desirable.  If Shiro's internal
+                // implementations used Subject sessions (setting attributes) whenever we wanted, it would be much
+                // harder for end-users to control when/where that occurs.
+                //
+                // Because of this, the SubjectDAO was created as the single point of control, and session state logic
+                // has been moved to the DefaultSubjectDAO implementation.
+
+                // Removed in Shiro 1.2.  SHIRO-157 is still satisfied by the new DefaultSubjectDAO implementation
+                // introduced in 1.2
+                // Satisfies SHIRO-157:
+                // bindPrincipalsToSession(principals, context);
+
+            } else {
+                log.trace("No remembered identity found.  Returning original context.");
+            }
+        }
+
+        return context;
+    }
+
+    protected SessionContext createSessionContext(SubjectContext subjectContext) {
+        DefaultSessionContext sessionContext = new DefaultSessionContext();
+        if (!CollectionUtils.isEmpty(subjectContext)) {
+            sessionContext.putAll(subjectContext);
+        }
+        Serializable sessionId = subjectContext.getSessionId();
+        if (sessionId != null) {
+            sessionContext.setSessionId(sessionId);
+        }
+        String host = subjectContext.resolveHost();
+        if (host != null) {
+            sessionContext.setHost(host);
+        }
+        return sessionContext;
+    }
+
+    public void logout(Subject subject) {
+
+        if (subject == null) {
+            throw new IllegalArgumentException("Subject method argument cannot be null.");
+        }
+
+        beforeLogout(subject);
+
+        PrincipalCollection principals = subject.getPrincipals();
+        if (principals != null && !principals.isEmpty()) {
+            if (log.isDebugEnabled()) {
+                log.debug("Logging out subject with primary principal {}", principals.getPrimaryPrincipal());
+            }
+            Authenticator authc = getAuthenticator();
+            if (authc instanceof LogoutAware) {
+                ((LogoutAware) authc).onLogout(principals);
+            }
+        }
+
+        try {
+            delete(subject);
+        } catch (Exception e) {
+            if (log.isDebugEnabled()) {
+                String msg = "Unable to cleanly unbind Subject.  Ignoring (logging out).";
+                log.debug(msg, e);
+            }
+        } finally {
+            try {
+                stopSession(subject);
+            } catch (Exception e) {
+                if (log.isDebugEnabled()) {
+                    String msg = "Unable to cleanly stop Session for Subject [" + subject.getPrincipal() + "] " +
+                                 "Ignoring (logging out).";
+                    log.debug(msg, e);
+                }
+            }
+        }
+    }
+
+    protected void stopSession(Subject subject) {
+        Session s = subject.getSession(false);
+        if (s != null) {
+            s.stop();
+        }
+    }
+
+    protected PrincipalCollection getRememberedIdentity(SubjectContext subjectContext) {
+        RememberMeManager rmm = getRememberMeManager();
+        if (rmm != null) {
+            try {
+                return rmm.getRememberedPrincipals(subjectContext);
+            } catch (Exception e) {
+                if (log.isWarnEnabled()) {
+                    String msg = "Delegate RememberMeManager instance of type [" + rmm.getClass().getName() +
+                                 "] threw an exception during getRememberedPrincipals().";
+                    log.warn(msg, e);
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/core/src/main/java/org/apache/shiro/mgt/AuthenticatingSecurityManager.java
+++ b/core/src/main/java/org/apache/shiro/mgt/AuthenticatingSecurityManager.java
@@ -18,6 +18,7 @@
  */
 package org.apache.shiro.mgt;
 
+import org.apache.shiro.account.Account;
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
@@ -39,7 +40,9 @@ import org.apache.shiro.util.LifecycleUtils;
  * possible, suitable default instances for all dependencies are created upon instantiation.
  *
  * @since 0.9
+ * @deprecated in 2.0 in favor of the simpler {@link ApplicationSecurityManager} implementation.
  */
+@Deprecated
 public abstract class AuthenticatingSecurityManager extends RealmSecurityManager {
 
     /**
@@ -102,8 +105,13 @@ public abstract class AuthenticatingSecurityManager extends RealmSecurityManager
     /**
      * Delegates to the wrapped {@link org.apache.shiro.authc.Authenticator Authenticator} for authentication.
      */
+    @Deprecated
     public AuthenticationInfo authenticate(AuthenticationToken token) throws AuthenticationException {
         return this.authenticator.authenticate(token);
+    }
+
+    public Account authenticateAccount(AuthenticationToken authenticationToken) throws AuthenticationException {
+        return this.authenticator.authenticateAccount(authenticationToken);
     }
 
     public void destroy() {

--- a/core/src/main/java/org/apache/shiro/mgt/AuthorizingSecurityManager.java
+++ b/core/src/main/java/org/apache/shiro/mgt/AuthorizingSecurityManager.java
@@ -43,7 +43,9 @@ import java.util.List;
  * possible, suitable default instances for all dependencies will be created upon instantiation.
  *
  * @since 0.9
+ * @deprecated in 2.0 in favor of the simpler {@link ApplicationSecurityManager} implementation.
  */
+@Deprecated
 public abstract class AuthorizingSecurityManager extends AuthenticatingSecurityManager {
 
     /**

--- a/core/src/main/java/org/apache/shiro/mgt/CachingSecurityManager.java
+++ b/core/src/main/java/org/apache/shiro/mgt/CachingSecurityManager.java
@@ -36,7 +36,9 @@ import org.apache.shiro.util.LifecycleUtils;
  * instance must be explicitly configured if caching across the framework is to be enabled.
  *
  * @since 0.9
+ * @deprecated in 2.0 in favor of the simpler {@link ApplicationSecurityManager} implementation.
  */
+@Deprecated
 public abstract class CachingSecurityManager implements SecurityManager, Destroyable, CacheManagerAware, EventBusAware {
 
     /**

--- a/core/src/main/java/org/apache/shiro/mgt/RealmSecurityManager.java
+++ b/core/src/main/java/org/apache/shiro/mgt/RealmSecurityManager.java
@@ -35,7 +35,9 @@ import java.util.Collection;
  * subclasses.
  *
  * @since 0.9
+ * @deprecated in 2.0 in favor of the simpler {@link ApplicationSecurityManager} implementation.
  */
+@Deprecated
 public abstract class RealmSecurityManager extends CachingSecurityManager {
 
     /**

--- a/core/src/main/java/org/apache/shiro/mgt/SessionsSecurityManager.java
+++ b/core/src/main/java/org/apache/shiro/mgt/SessionsSecurityManager.java
@@ -45,7 +45,9 @@ import org.apache.shiro.util.LifecycleUtils;
  * possible, suitable default instances for all dependencies will be created upon instantiation.
  *
  * @since 0.9
+ * @deprecated in 2.0 in favor of the simpler {@link ApplicationSecurityManager} implementation.
  */
+@Deprecated
 public abstract class SessionsSecurityManager extends AuthorizingSecurityManager {
 
     /**

--- a/core/src/main/java/org/apache/shiro/realm/AbstractCacheHandler.java
+++ b/core/src/main/java/org/apache/shiro/realm/AbstractCacheHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.realm;
+
+import org.apache.shiro.cache.CacheManager;
+import org.apache.shiro.cache.DisabledCacheManager;
+
+/**
+ * @since 2.0
+ */
+public abstract class AbstractCacheHandler {
+
+    private CacheManager cacheManager;
+
+    public AbstractCacheHandler() {
+        this.cacheManager = DisabledCacheManager.INSTANCE;
+    }
+
+    public CacheManager getCacheManager() {
+        return cacheManager;
+    }
+
+    public void setCacheManager(CacheManager cacheManager) {
+        this.cacheManager = cacheManager;
+    }
+}

--- a/core/src/main/java/org/apache/shiro/realm/AccountCacheHandler.java
+++ b/core/src/main/java/org/apache/shiro/realm/AccountCacheHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.realm;
+
+import org.apache.shiro.account.Account;
+import org.apache.shiro.account.AccountId;
+import org.apache.shiro.authc.AuthenticationToken;
+
+/**
+ * @since 2.0
+ */
+public interface AccountCacheHandler {
+
+    Account getCachedAccount(AuthenticationToken token);
+
+    void cacheAccount(AuthenticationToken token, Account account);
+
+    void clearCachedAccount(AccountId id);
+
+}

--- a/core/src/main/java/org/apache/shiro/realm/AccountCacheKeyResolver.java
+++ b/core/src/main/java/org/apache/shiro/realm/AccountCacheKeyResolver.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.realm;
+
+import org.apache.shiro.account.Account;
+import org.apache.shiro.account.AccountId;
+import org.apache.shiro.authc.AuthenticationToken;
+
+/**
+ * @since 2.0
+ */
+public interface AccountCacheKeyResolver {
+
+    Object getAccountCacheKey(AuthenticationToken token);
+
+    Object getAccountCacheKey(AuthenticationToken token, Account account);
+
+    Object getAccountCacheKey(AccountId id);
+}

--- a/core/src/main/java/org/apache/shiro/realm/AccountCacheResolver.java
+++ b/core/src/main/java/org/apache/shiro/realm/AccountCacheResolver.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.realm;
+
+import org.apache.shiro.account.Account;
+import org.apache.shiro.account.AccountId;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.cache.Cache;
+
+/**
+ * @since 2.0
+ */
+public interface AccountCacheResolver {
+
+    Cache<Object,Account> getAccountCache(AuthenticationToken token);
+
+    Cache<Object,Account> getAccountCache(AuthenticationToken token, Account account);
+
+    Cache<Object,Account> getAccountCache(AccountId id);
+}

--- a/core/src/main/java/org/apache/shiro/realm/AccountPermissionResolver.java
+++ b/core/src/main/java/org/apache/shiro/realm/AccountPermissionResolver.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.realm;
+
+/**
+ * @since 2.0
+ */
+public interface AccountPermissionResolver {
+}

--- a/core/src/main/java/org/apache/shiro/realm/AccountRolePermissionResolver.java
+++ b/core/src/main/java/org/apache/shiro/realm/AccountRolePermissionResolver.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.realm;
+
+import org.apache.shiro.account.Account;
+import org.apache.shiro.authz.Permission;
+
+import java.util.Collection;
+
+/**
+ * @since 2.0
+ */
+public interface AccountRolePermissionResolver {
+
+    /**
+     * Returns all permissions assigned to the role with the specified {@code roleName}.  The role is one of the
+     * account's assigned roles.
+     *
+     * @param account the account assigned the specified role.
+     * @param roleName the name of the role for which permissions will be resolved.
+     * @return all permissions assigned to the role with the specified {@code roleName}.
+     */
+    Collection<Permission> getAccountRolePermissions(Account account, String roleName);
+}

--- a/core/src/main/java/org/apache/shiro/realm/AccountRoleResolver.java
+++ b/core/src/main/java/org/apache/shiro/realm/AccountRoleResolver.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.realm;
+
+import org.apache.shiro.account.Account;
+
+import java.util.Collection;
+
+/**
+ * @since 2.0
+ */
+public interface AccountRoleResolver {
+
+    /**
+     * Returns a collection of the names of all Roles assigned to the specified Account.
+     *
+     * @param account the account for which assigned roles will be found.
+     * @return a collection of the names of all Roles assigned to the specified Account.
+     */
+    Collection<String> getAccountRoleNames(Account account);
+}

--- a/core/src/main/java/org/apache/shiro/realm/AccountStoreRealm.java
+++ b/core/src/main/java/org/apache/shiro/realm/AccountStoreRealm.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.realm;
+
+import org.apache.shiro.account.Account;
+import org.apache.shiro.account.AccountStore;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.IncorrectCredentialsException;
+import org.apache.shiro.authc.UsernamePasswordToken;
+import org.apache.shiro.authc.credential.CredentialsMatcher;
+import org.apache.shiro.authc.credential.PasswordMatcher;
+import org.apache.shiro.util.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Performs authentication and authorization for accounts in a <em>single</em> account data store.  It is expected
+ * that you configure one {@code AccountStoreRealm} for each data store that contains accounts accessible to your
+ * application.
+ *
+ * @since 2.0
+ */
+public class AccountStoreRealm implements Realm {
+
+    private static final Logger log = LoggerFactory.getLogger(AccountStoreRealm.class);
+
+    private String name;
+
+    private AccountStore accountStore;
+
+    //Authentication:
+    private CredentialsMatcher credentialsMatcher;
+    private AccountCacheHandler accountCacheHandler;
+
+    //Authorization:
+    private AuthorizationCacheHandler authorizationCacheHandler;
+    private AccountRoleResolver accountRoleResolver;
+    private AccountRolePermissionResolver accountRolePermissionResolver;
+    private AccountPermissionResolver accountPermissionResolver;
+
+    public AccountStoreRealm() {
+        this.credentialsMatcher = new PasswordMatcher(); //80/20 rule: most Shiro deployments use passwords
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public AccountStore getAccountStore() {
+        return accountStore;
+    }
+
+    public void setAccountStore(AccountStore accountStore) {
+        Assert.notNull(accountStore);
+        this.accountStore = accountStore;
+    }
+
+    public CredentialsMatcher getCredentialsMatcher() {
+        return credentialsMatcher;
+    }
+
+    public void setCredentialsMatcher(CredentialsMatcher credentialsMatcher) {
+        Assert.notNull(credentialsMatcher);
+        this.credentialsMatcher = credentialsMatcher;
+    }
+
+    public AccountCacheHandler getAccountCacheHandler() {
+        return accountCacheHandler;
+    }
+
+    public void setAccountCacheHandler(AccountCacheHandler accountCacheHandler) {
+        Assert.notNull(accountCacheHandler);
+        this.accountCacheHandler = accountCacheHandler;
+    }
+
+    public AuthorizationCacheHandler getAuthorizationCacheHandler() {
+        return authorizationCacheHandler;
+    }
+
+    public void setAuthorizationCacheHandler(AuthorizationCacheHandler authorizationCacheHandler) {
+        Assert.notNull(authorizationCacheHandler);
+        this.authorizationCacheHandler = authorizationCacheHandler;
+    }
+
+    public boolean supports(AuthenticationToken token) {
+        return UsernamePasswordToken.class.isInstance(token);
+    }
+
+    @Deprecated
+    public final AuthenticationInfo getAuthenticationInfo(AuthenticationToken token) throws AuthenticationException {
+        throw new UnsupportedOperationException("The " + getClass().getName() + " implementation does not support " +
+                "legacy (pre 2.0) authentication behavior.  Do not configure this Realm unless you are using " +
+                "a DefaultAuthenticator implementation.");
+    }
+
+    @Deprecated
+    public final AuthenticationInfo authenticate(AuthenticationToken token) throws AuthenticationException {
+        throw new UnsupportedOperationException("The " + getClass().getName() + " implementation does not support " +
+                "legacy (pre 2.0) authentication behavior.  Do not configure this Realm unless you are using " +
+                "a DefaultAuthenticator implementation.");
+    }
+
+    public Account authenticateAccount(AuthenticationToken token) throws AuthenticationException {
+        Account account = accountCacheHandler.getCachedAccount(token);
+        if (account == null) {
+            //otherwise not cached, perform the lookup:
+            account = accountStore.getAccount(token);
+            if (token != null && account != null) {
+                log.debug("Acquired Account [{}] from account store", account);
+                accountCacheHandler.cacheAccount(token, account);
+            }
+        } else {
+            log.debug("Using cached account [{}] for credentials matching.", account);
+        }
+
+        if (account == null) {
+            log.debug("No account found for submitted AuthenticationToken [{}].  Returning null.", token);
+            return null;
+        }
+
+        assertCredentialsMatch(token, account);
+
+        return account;
+    }
+
+    protected void assertCredentialsMatch(AuthenticationToken token, Account account) {
+        CredentialsMatcher cm = getCredentialsMatcher();
+        if (!cm.credentialsMatch(token, account)) {
+            //not successful - throw an exception to indicate this:
+            String msg = "Submitted credentials for token [" + token + "] did not match the stored credentials.";
+            throw new IncorrectCredentialsException(msg);
+        }
+    }
+}

--- a/core/src/main/java/org/apache/shiro/realm/AuthorizationCacheHandler.java
+++ b/core/src/main/java/org/apache/shiro/realm/AuthorizationCacheHandler.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.realm;
+
+import org.apache.shiro.account.AccountId;
+import org.apache.shiro.authz.AuthorizationInfo;
+
+/**
+ * @since 2.0
+ */
+public interface AuthorizationCacheHandler {
+
+    AuthorizationInfo getCachedAuthorizationInfo(AccountId id);
+
+    void cacheAuthorizationInfo(AccountId id, AuthorizationInfo info);
+
+}

--- a/core/src/main/java/org/apache/shiro/realm/CachingRealm.java
+++ b/core/src/main/java/org/apache/shiro/realm/CachingRealm.java
@@ -44,7 +44,9 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @see #onLogout(org.apache.shiro.subject.PrincipalCollection)
  * @see #getAvailablePrincipal(org.apache.shiro.subject.PrincipalCollection)
  * @since 0.9
+ * @deprecated since 2.0 if favor of the {@link AccountStoreRealm} configured with an {@link org.apache.shiro.account.AccountStore AccountStore}.
  */
+@Deprecated
 public abstract class CachingRealm implements Realm, Nameable, CacheManagerAware, LogoutAware {
 
     private static final Logger log = LoggerFactory.getLogger(CachingRealm.class);

--- a/core/src/main/java/org/apache/shiro/realm/DefaultAccountCacheHandler.java
+++ b/core/src/main/java/org/apache/shiro/realm/DefaultAccountCacheHandler.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.realm;
+
+import org.apache.shiro.account.Account;
+import org.apache.shiro.account.AccountId;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.cache.Cache;
+
+/**
+ * @since 2.0
+ */
+public class DefaultAccountCacheHandler extends AbstractCacheHandler implements AccountCacheHandler {
+
+    private AccountCacheKeyResolver accountCacheKeyResolver;
+    private AccountCacheResolver accountCacheResolver;
+
+    public DefaultAccountCacheHandler() {
+    }
+
+    public Account getCachedAccount(AuthenticationToken token) {
+        Cache<Object,Account> cache = accountCacheResolver.getAccountCache(token);
+        Object key = accountCacheKeyResolver.getAccountCacheKey(token);
+        return cache.get(key);
+    }
+
+    public void cacheAccount(AuthenticationToken token, Account account) {
+        Cache<Object,Account> cache = accountCacheResolver.getAccountCache(token, account);
+        Object key = accountCacheKeyResolver.getAccountCacheKey(token, account);
+        cache.put(key, account);
+    }
+
+    public void clearCachedAccount(AccountId id) {
+        Cache<Object,Account> cache = accountCacheResolver.getAccountCache(id);
+        Object key = accountCacheKeyResolver.getAccountCacheKey(id);
+        cache.remove(key);
+    }
+
+    public AccountCacheKeyResolver getAccountCacheKeyResolver() {
+        return accountCacheKeyResolver;
+    }
+
+    public void setAccountCacheKeyResolver(AccountCacheKeyResolver accountCacheKeyResolver) {
+        this.accountCacheKeyResolver = accountCacheKeyResolver;
+    }
+
+    public AccountCacheResolver getAccountCacheResolver() {
+        return accountCacheResolver;
+    }
+
+    public void setAccountCacheResolver(AccountCacheResolver accountCacheResolver) {
+        this.accountCacheResolver = accountCacheResolver;
+    }
+}

--- a/core/src/main/java/org/apache/shiro/realm/Realm.java
+++ b/core/src/main/java/org/apache/shiro/realm/Realm.java
@@ -21,73 +21,73 @@ package org.apache.shiro.realm;
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.Authenticator;
 
 /**
- * A <tt>Realm</tt> is a security component that can access application-specific security entities
- * such as users, roles, and permissions to determine authentication and authorization operations.
- *
- * <p><tt>Realm</tt>s usually have a 1-to-1 correspondance with a datasource such as a relational database,
- * file sysetem, or other similar resource.  As such, implementations of this interface use datasource-specific APIs to
- * determine authorization data (roles, permissions, etc), such as JDBC, File IO, Hibernate or JPA, or any other
- * Data Access API.  They are essentially security-specific
- * <a href="http://en.wikipedia.org/wiki/Data_Access_Object" target="_blank">DAO</a>s.
- *
- * <p>Because most of these datasources usually contain Subject (a.k.a. User) information such as usernames and
+ * A {@code Realm} access application-specific security entities
+ * such as accounts, roles, and permissions to perform authentication and authorization operations.
+ * <p/>
+ * {@code Realm}s usually have a 1-to-1 correlation with an {@link org.apache.shiro.account.AccountStore account store}
+ * such as a NoSQL or relational database, file system, or other similar resource.  However, because most Realm
+ * implementations are nearly identical, except for the account query logic, a default realm implementation -
+ * {@link AccountStoreRealm} - is provided out of the box, allowing you to configure it with the data API-specific
+ * {@link org.apache.shiro.account.AccountStore AccountStore} instance.
+ * <p/>
+ * Because most account stores usually contain Subject information such as usernames and
  * passwords, a Realm can act as a pluggable authentication module in a
- * <a href="http://en.wikipedia.org/wiki/Pluggable_Authentication_Modules">PAM</a> configuration.  This allows a Realm to
- * perform <i>both</i> authentication and authorization duties for a single datasource, which caters to the large
- * majority of applications.  If for some reason you don't want your Realm implementation to perform authentication
- * duties, you should override the {@link #supports(org.apache.shiro.authc.AuthenticationToken)} method to always
- * return <tt>false</tt>.
- *
- * <p>Because every application is different, security data such as users and roles can be
+ * <a href="http://en.wikipedia.org/wiki/Pluggable_Authentication_Modules">PAM</a> configuration.  This allows a Realm
+ * to perform <i>both</i> authentication and authorization duties for a single account store, which caters to most
+ * application needs.  If for some reason you don't want your Realm implementation to participate in authentication,
+ * you should override the {@link #supports(org.apache.shiro.authc.AuthenticationToken)} method to always
+ * return {@code false}.
+ * <p/>
+ * Because every application is different, security data such as users and roles can be
  * represented in any number of ways.  Shiro tries to maintain a non-intrusive development philosophy whenever
  * possible - it does not require you to implement or extend any <tt>User</tt>, <tt>Group</tt> or <tt>Role</tt>
  * interfaces or classes.
- *
- * <p>Instead, Shiro allows applications to implement this interface to access environment-specific datasources
+ * <p/>
+ * Instead, Shiro allows applications to implement this interface to access environment-specific account stores
  * and data model objects.  The implementation can then be plugged in to the application's Shiro configuration.
  * This modular technique abstracts away any environment/modeling details and allows Shiro to be deployed in
  * practically any application environment.
+ * <p/>
+ * Most users will not implement this {@code Realm} interface directly, but will instead use an
+ * {@link AccountStoreRealm} instance and configure it with an {@link org.apache.shiro.account.AccountStore AccountStore}.
+ * This implies there would be an {@code AccountStoreRealm} instance per {@code AccountStore} that the application needs
+ * to access.
  *
- * <p>Most users will not implement the <tt>Realm</tt> interface directly, but will extend one of the subclasses,
- * {@link org.apache.shiro.realm.AuthenticatingRealm AuthenticatingRealm} or {@link org.apache.shiro.realm.AuthorizingRealm}, greatly reducing the effort requird
- * to implement a <tt>Realm</tt> from scratch.</p>
- *
- * @see org.apache.shiro.realm.CachingRealm CachingRealm
- * @see org.apache.shiro.realm.AuthenticatingRealm AuthenticatingRealm
- * @see org.apache.shiro.realm.AuthorizingRealm AuthorizingRealm
- * @see org.apache.shiro.authc.pam.ModularRealmAuthenticator ModularRealmAuthenticator
+ * @see AccountStoreRealm
  * @since 0.1
  */
-public interface Realm {
+public interface Realm extends Authenticator {
 
     /**
-     * Returns the (application-unique) name assigned to this <code>Realm</code>. All realms configured for a single
+     * Returns the (application-unique) name assigned to this {@code Realm}. All realms configured for a single
      * application must have a unique name.
      *
-     * @return the (application-unique) name assigned to this <code>Realm</code>.
+     * @return the (application-unique) name assigned to this {@code Realm}.
      */
     String getName();
 
     /**
-     * Returns <tt>true</tt> if this realm wishes to authenticate the Subject represented by the given
-     * {@link org.apache.shiro.authc.AuthenticationToken AuthenticationToken} instance, <tt>false</tt> otherwise.
-     *
-     * <p>If this method returns <tt>false</tt>, it will not be called to authenticate the Subject represented by
-     * the token - more specifically, a <tt>false</tt> return value means this Realm instance's
-     * {@link #getAuthenticationInfo} method will not be invoked for that token.
+     * Returns {@code true} if this realm can/will authenticate the account corresponding to the specified
+     * {@link org.apache.shiro.authc.AuthenticationToken AuthenticationToken} instance, {@code false} otherwise.
+     * <p/>
+     * If this method returns {@code false}, it will not be called to authenticate the account represented by
+     * the token - more specifically, a {@code false} return value means the Realm instance's
+     * {@link #authenticateAccount(org.apache.shiro.authc.AuthenticationToken)} method will not be invoked for the
+     * specified token.
      *
      * @param token the AuthenticationToken submitted for the authentication attempt
-     * @return <tt>true</tt> if this realm can/will authenticate Subjects represented by specified token,
-     *         <tt>false</tt> otherwise.
+     * @return {@code true} if this realm can/will authenticate the account corresponding to the specified token,
+     *         {@code false} otherwise.
      */
     boolean supports(AuthenticationToken token);
 
     /**
      * Returns an account's authentication-specific information for the specified <tt>token</tt>,
      * or <tt>null</tt> if no account could be found based on the <tt>token</tt>.
-     *
+     * <p/>
      * <p>This method effectively represents a login attempt for the corresponding user with the underlying EIS datasource.
      * Most implementations merely just need to lookup and return the account data only (as the method name implies)
      * and let Shiro do the rest, but implementations may of course perform eis specific login operations if so
@@ -99,7 +99,11 @@ public interface Realm {
      * @throws org.apache.shiro.authc.AuthenticationException
      *          if there is an error obtaining or constructing an AuthenticationInfo object based on the
      *          specified <tt>token</tt> or implementation-specifc login behavior fails.
+     * @deprecated as of Shiro 2.0, Realm extends Authenticator.  Implement
+     *             {@link #authenticateAccount(org.apache.shiro.authc.AuthenticationToken)} and have this method
+     *             delegate to it.  This method will be removed before the 2.0 final release.
      */
+    @Deprecated
     AuthenticationInfo getAuthenticationInfo(AuthenticationToken token) throws AuthenticationException;
 
 }

--- a/core/src/main/java/org/apache/shiro/realm/RealmAccount.java
+++ b/core/src/main/java/org/apache/shiro/realm/RealmAccount.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.realm;
+
+import org.apache.shiro.account.Account;
+
+/**
+ * An account that also represents the realm from which it was obtained.
+ *
+ * @since 2.0
+ */
+public interface RealmAccount extends Account {
+
+    String getRealmName();
+}

--- a/core/src/main/java/org/apache/shiro/realm/SimpleAccountRealm.java
+++ b/core/src/main/java/org/apache/shiro/realm/SimpleAccountRealm.java
@@ -47,7 +47,9 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * is not sufficiently large.
  *
  * @since 0.1
+ * @deprecated since 2.0 if favor of the {@link AccountStoreRealm} configured with a simple in-memory {@link org.apache.shiro.account.AccountStore AccountStore}.
  */
+@Deprecated
 public class SimpleAccountRealm extends AuthorizingRealm {
 
     //TODO - complete JavaDoc

--- a/core/src/main/java/org/apache/shiro/realm/activedirectory/ActiveDirectoryRealm.java
+++ b/core/src/main/java/org/apache/shiro/realm/activedirectory/ActiveDirectoryRealm.java
@@ -39,7 +39,11 @@ import javax.naming.directory.Attributes;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
 import javax.naming.ldap.LdapContext;
-import java.util.*;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -49,7 +53,9 @@ import java.util.*;
  * {@link #groupRolesMap}.
  *
  * @since 0.1
+ * @deprecated since 2.0 if favor of the {@link org.apache.shiro.realm.AccountStoreRealm} configured with an ActiveDirectory-specific {@link org.apache.shiro.account.AccountStore AccountStore}.
  */
+@Deprecated
 public class ActiveDirectoryRealm extends AbstractLdapRealm {
 
     //TODO - complete JavaDoc

--- a/core/src/main/java/org/apache/shiro/realm/jdbc/JdbcRealm.java
+++ b/core/src/main/java/org/apache/shiro/realm/jdbc/JdbcRealm.java
@@ -59,7 +59,9 @@ import java.util.Set;
  * This realm supports caching by extending from {@link org.apache.shiro.realm.AuthorizingRealm}.
  *
  * @since 0.2
+ * @deprecated since 2.0 if favor of the {@link org.apache.shiro.realm.AccountStoreRealm} configured with a JDBC-specific {@link org.apache.shiro.account.AccountStore AccountStore}.
  */
+@Deprecated
 public class JdbcRealm extends AuthorizingRealm {
 
     //TODO - complete JavaDoc

--- a/core/src/main/java/org/apache/shiro/realm/ldap/AbstractLdapRealm.java
+++ b/core/src/main/java/org/apache/shiro/realm/ldap/AbstractLdapRealm.java
@@ -49,7 +49,9 @@ import javax.naming.NamingException;
  * @see #queryForAuthenticationInfo(org.apache.shiro.authc.AuthenticationToken , LdapContextFactory)
  * @see #queryForAuthorizationInfo(org.apache.shiro.subject.PrincipalCollection , LdapContextFactory)
  * @since 0.1
+ * @deprecated since 2.0 if favor of the {@link org.apache.shiro.realm.AccountStoreRealm} configured with an LDAP-specific {@link org.apache.shiro.account.AccountStore AccountStore}.
  */
+@Deprecated
 public abstract class AbstractLdapRealm extends AuthorizingRealm {
 
     //TODO - complete JavaDoc

--- a/core/src/main/java/org/apache/shiro/realm/ldap/JndiLdapRealm.java
+++ b/core/src/main/java/org/apache/shiro/realm/ldap/JndiLdapRealm.java
@@ -80,7 +80,9 @@ import javax.naming.ldap.LdapContext;
  * @see JndiLdapContextFactory
  *
  * @since 1.1
+ * @deprecated since 2.0 if favor of the {@link org.apache.shiro.realm.AccountStoreRealm} configured with an LDAP-specific {@link org.apache.shiro.account.AccountStore AccountStore}.
  */
+@Deprecated
 public class JndiLdapRealm extends AuthorizingRealm {
 
     private static final Logger log = LoggerFactory.getLogger(JndiLdapRealm.class);

--- a/core/src/main/java/org/apache/shiro/realm/text/IniRealm.java
+++ b/core/src/main/java/org/apache/shiro/realm/text/IniRealm.java
@@ -41,7 +41,9 @@ import org.slf4j.LoggerFactory;
  * data from an .ini resource.  This will only be used if there isn't already account data in the Realm.
  *
  * @since 1.0
+ * @deprecated since 2.0 if favor of the {@link org.apache.shiro.realm.AccountStoreRealm} configured with an Ini-specific {@link org.apache.shiro.account.AccountStore AccountStore}.
  */
+@Deprecated
 public class IniRealm extends TextConfigurationRealm {
 
     public static final String USERS_SECTION_NAME = "users";

--- a/core/src/main/java/org/apache/shiro/realm/text/PropertiesRealm.java
+++ b/core/src/main/java/org/apache/shiro/realm/text/PropertiesRealm.java
@@ -80,7 +80,9 @@ import java.util.concurrent.TimeUnit;
  * role.contractor = application:use:timesheet</code>
  *
  * @since 0.2
+ * @deprecated since 2.0 if favor of the {@link org.apache.shiro.realm.AccountStoreRealm} configured with a Properties-based {@link org.apache.shiro.account.AccountStore AccountStore}.
  */
+@Deprecated
 public class PropertiesRealm extends TextConfigurationRealm implements Destroyable, Runnable {
 
     //TODO - complete JavaDoc

--- a/core/src/main/java/org/apache/shiro/realm/text/TextConfigurationRealm.java
+++ b/core/src/main/java/org/apache/shiro/realm/text/TextConfigurationRealm.java
@@ -47,7 +47,9 @@ import java.util.Set;
  * Role-to-permission definitions are specified via the {@link #setRoleDefinitions} method.
  *
  * @since 0.9
+ * @deprecated since 2.0 if favor of the {@link org.apache.shiro.realm.AccountStoreRealm} configured with an text config-specific {@link org.apache.shiro.account.AccountStore AccountStore}.
  */
+@Deprecated
 public class TextConfigurationRealm extends SimpleAccountRealm {
 
     //TODO - complete JavaDoc

--- a/core/src/test/groovy/org/apache/shiro/realm/CachingRealmTest.groovy
+++ b/core/src/test/groovy/org/apache/shiro/realm/CachingRealmTest.groovy
@@ -18,11 +18,14 @@
  */
 package org.apache.shiro.realm
 
+import org.apache.shiro.account.Account
+import org.apache.shiro.authc.AuthenticationException
 import org.apache.shiro.authc.AuthenticationInfo
 import org.apache.shiro.authc.AuthenticationToken
 import org.apache.shiro.cache.Cache
 import org.apache.shiro.cache.CacheManager
 import org.apache.shiro.subject.PrincipalCollection
+
 import static org.easymock.EasyMock.*
 
 /**
@@ -133,6 +136,7 @@ class CachingRealmTest extends GroovyTestCase {
     private static final class TestCachingRealm extends CachingRealm {
 
         def info;
+        def account;
 
         boolean templateMethodCalled = false
         boolean doClearCacheCalled = false
@@ -143,6 +147,14 @@ class CachingRealmTest extends GroovyTestCase {
 
         AuthenticationInfo getAuthenticationInfo(AuthenticationToken token) {
             return info;
+        }
+
+        AuthenticationInfo authenticate(AuthenticationToken authenticationToken) throws AuthenticationException {
+            return info;
+        }
+
+        Account authenticateAccount(AuthenticationToken authenticationToken) throws AuthenticationException {
+            return account;
         }
 
         @Override

--- a/core/src/test/java/org/apache/shiro/authc/AbstractAuthenticatorTest.java
+++ b/core/src/test/java/org/apache/shiro/authc/AbstractAuthenticatorTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.shiro.authc;
 
+import org.apache.shiro.account.Account;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -38,6 +39,10 @@ public class AbstractAuthenticatorTest {
             protected AuthenticationInfo doAuthenticate(AuthenticationToken token) throws AuthenticationException {
                 return null;
             }
+
+            public Account authenticateAccount(AuthenticationToken authenticationToken) throws AuthenticationException {
+                return null;
+            }
         };
     }
 
@@ -45,6 +50,10 @@ public class AbstractAuthenticatorTest {
         return new AbstractAuthenticator() {
             protected AuthenticationInfo doAuthenticate(AuthenticationToken token) throws AuthenticationException {
                 return info;
+            }
+
+            public Account authenticateAccount(AuthenticationToken authenticationToken) throws AuthenticationException {
+                throw new UnsupportedOperationException("Not yet implemented.");
             }
         };
     }
@@ -63,6 +72,10 @@ public class AbstractAuthenticatorTest {
         abstractAuthenticator = new AbstractAuthenticator() {
             protected AuthenticationInfo doAuthenticate(AuthenticationToken token) throws AuthenticationException {
                 return info;
+            }
+
+            public Account authenticateAccount(AuthenticationToken authenticationToken) throws AuthenticationException {
+                throw new UnsupportedOperationException("Not yet implemented.");
             }
         };
     }
@@ -121,6 +134,10 @@ public class AbstractAuthenticatorTest {
             protected AuthenticationInfo doAuthenticate(AuthenticationToken token) throws AuthenticationException {
                 throw ae;
             }
+
+            public Account authenticateAccount(AuthenticationToken authenticationToken) throws AuthenticationException {
+                throw new UnsupportedOperationException("Not yet implemented.");
+            }
         };
         abstractAuthenticator.getAuthenticationListeners().add(mockListener);
 
@@ -146,6 +163,10 @@ public class AbstractAuthenticatorTest {
         abstractAuthenticator = new AbstractAuthenticator() {
             protected AuthenticationInfo doAuthenticate(AuthenticationToken token) throws AuthenticationException {
                 throw new IllegalArgumentException("not an AuthenticationException subclass");
+            }
+
+            public Account authenticateAccount(AuthenticationToken authenticationToken) throws AuthenticationException {
+                throw new UnsupportedOperationException("Not yet implemented.");
             }
         };
         AuthenticationToken token = newToken();

--- a/core/src/test/java/org/apache/shiro/realm/activedirectory/ActiveDirectoryRealmTest.java
+++ b/core/src/test/java/org/apache/shiro/realm/activedirectory/ActiveDirectoryRealmTest.java
@@ -19,7 +19,12 @@
 package org.apache.shiro.realm.activedirectory;
 
 import org.apache.shiro.SecurityUtils;
-import org.apache.shiro.authc.*;
+import org.apache.shiro.account.Account;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.SimpleAccount;
+import org.apache.shiro.authc.UsernamePasswordToken;
 import org.apache.shiro.authc.credential.CredentialsMatcher;
 import org.apache.shiro.authz.AuthorizationInfo;
 import org.apache.shiro.authz.SimpleAuthorizationInfo;
@@ -40,7 +45,7 @@ import javax.naming.NamingException;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 
 /**
@@ -110,6 +115,10 @@ public class ActiveDirectoryRealmTest {
 
             credentialsMatcher = new CredentialsMatcher() {
                 public boolean doCredentialsMatch(AuthenticationToken object, AuthenticationInfo object1) {
+                    return true;
+                }
+
+                public boolean credentialsMatch(AuthenticationToken token, Account account) {
                     return true;
                 }
             };

--- a/pom.xml
+++ b/pom.xml
@@ -179,8 +179,7 @@
             <name>Brian Demers</name>
             <email>bdemers@apache.org</email>
             <url>http://about.me/brian.demers</url>
-            <organization>Sonatype</organization>
-            <organizationUrl>http://www.sonatype.com/</organizationUrl>
+            <organization>Apache Software Foundation</organization>
             <timezone>-5</timezone>
         </developer>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <!-- Compile 3rd party dependencies: -->
         <!-- Don't change this version without also changing the shiro-aspect and shiro-features
              modules' OSGi metadata: -->
-        <aspectj.version>1.6.12</aspectj.version>
+        <aspectj.version>1.8.2</aspectj.version>
         <commons.cli.version>1.2</commons.cli.version>
         <commons.codec.version>1.4</commons.codec.version>
         <crowd.version>1.5.2</crowd.version>
@@ -83,7 +83,7 @@
         <!-- Don't change this version without also changing the shiro-hazelcast and shiro-features OSGi metadata: -->
         <hazelcast.version>2.4.1</hazelcast.version>
         <hsqldb.version>1.8.0.7</hsqldb.version>
-        <jdk.version>1.5</jdk.version>
+        <jdk.version>1.7</jdk.version>
         <jetty.version>6.1.26</jetty.version>
         <openid4j.version>0.9.5</openid4j.version>
         <!-- Don't change this version without also changing the shiro-quartz and shiro-features
@@ -1026,7 +1026,7 @@
                 <version>2.5</version>
                 <configuration>
                     <sourceEncoding>utf-8</sourceEncoding>
-                    <targetJdk>1.5</targetJdk>
+                    <targetJdk>${jdk.version}</targetJdk>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/aspectj/pom.xml
+++ b/samples/aspectj/pom.xml
@@ -36,10 +36,11 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>aspectj-maven-plugin</artifactId>
-				<version>1.4</version>
+				<version>1.7</version>
 				<configuration>
-					<source>1.5</source>
-					<target>1.5</target>
+                    <complianceLevel>${jdk.version}</complianceLevel>
+					<source>${jdk.version}</source>
+					<target>${jdk.version}</target>
 					<showWeaveInfo>true</showWeaveInfo>
 					<aspectLibraries>
 						<aspectLibrary>

--- a/samples/guice/pom.xml
+++ b/samples/guice/pom.xml
@@ -38,6 +38,7 @@
 	            <artifactId>maven-surefire-plugin</artifactId>
 	            <configuration>
 	                <forkMode>never</forkMode>
+	                <useSystemClassLoader>false</useSystemClassLoader>
 	            </configuration>
 	        </plugin>
 	        <plugin>

--- a/samples/spring-client/pom.xml
+++ b/samples/spring-client/pom.xml
@@ -90,7 +90,22 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>webstart-maven-plugin</artifactId>
-                <version>1.0-beta-3</version>
+                <version>1.0-beta-6</version>
+                <dependencies>
+                    <!-- The following two dependencies are needed when building with JDK 1.8
+                         This has been fixed in 1.0-beta-7 (which is not released yet) -->
+                    <dependency>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>webstart-pack200-impl</artifactId>
+                        <version>1.0-beta-6</version>
+                        <scope>runtime</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>keytool-api-1.7</artifactId>
+                        <version>1.5</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -111,13 +126,15 @@
                     </jnlp>
 
                     <sign>
-                        <keystore>jsecurity-sample.jks</keystore>
+                        <keystore>${build.directory}/jnlp/jsecurity-sample.jks</keystore>
                         <storepass>jsecurity</storepass>
                         <alias>jsecurity</alias>
                         <verify>false</verify>
                     </sign>
                     <!-- BUILDING PROCESS -->
-                    <pack200>true</pack200>
+                    <pack200>
+                        <enabled>true</enabled>
+                    </pack200>
                     <verbose>false</verbose>
 
                 </configuration>

--- a/samples/spring-client/pom.xml
+++ b/samples/spring-client/pom.xml
@@ -126,7 +126,7 @@
                     </jnlp>
 
                     <sign>
-                        <keystore>${build.directory}/jnlp/jsecurity-sample.jks</keystore>
+                        <keystore>${project.build.directory}/jnlp/jsecurity-sample.jks</keystore>
                         <storepass>jsecurity</storepass>
                         <alias>jsecurity</alias>
                         <verify>false</verify>

--- a/samples/spring/pom.xml
+++ b/samples/spring/pom.xml
@@ -99,11 +99,11 @@
                         <id>replace-jnlp-file</id>
                         <phase>process-resources</phase>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <!-- move would be more appropriate but it would fail on repetitive executions of
                                      jetty:run for example, leaving the original in place doesn't hurt -->
                                 <copy file="${project.build.directory}/${project.build.finalName}/shiro.jnlp.jsp" todir="${project.build.directory}/${project.build.finalName}/WEB-INF/resources" />
-                            </tasks>
+                            </target>
                         </configuration>
                         <goals>
                             <goal>run</goal>

--- a/samples/spring/src/main/java/org/apache/shiro/samples/spring/realm/SaltAwareJdbcRealm.java
+++ b/samples/spring/src/main/java/org/apache/shiro/samples/spring/realm/SaltAwareJdbcRealm.java
@@ -18,7 +18,13 @@
  */
 package org.apache.shiro.samples.spring.realm;
 
-import org.apache.shiro.authc.*;
+import org.apache.shiro.authc.AccountException;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.SimpleAuthenticationInfo;
+import org.apache.shiro.authc.UnknownAccountException;
+import org.apache.shiro.authc.UsernamePasswordToken;
 import org.apache.shiro.realm.jdbc.JdbcRealm;
 import org.apache.shiro.util.ByteSource;
 import org.apache.shiro.util.JdbcUtils;
@@ -33,7 +39,9 @@ import java.sql.SQLException;
 /**
  * Realm that exists to support salted credentials.  The JdbcRealm implementation needs to be updated in a future
  * Shiro release to handle this.
+ * @deprecated since 2.0 if favor of the {@link org.apache.shiro.realm.AccountStoreRealm} configured with an JDBC-specific {@link org.apache.shiro.account.AccountStore AccountStore}.
  */
+@Deprecated
 public class SaltAwareJdbcRealm extends JdbcRealm {
 
     private static final Logger log = LoggerFactory.getLogger(SaltAwareJdbcRealm.class);

--- a/samples/web/pom.xml
+++ b/samples/web/pom.xml
@@ -38,6 +38,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <forkMode>never</forkMode>
+                    <useSystemClassLoader>false</useSystemClassLoader>
                 </configuration>
             </plugin>
             <plugin>

--- a/support/aspectj/pom.xml
+++ b/support/aspectj/pom.xml
@@ -64,11 +64,18 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
-                <version>1.4</version>
+                <version>1.7</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.aspectj</groupId>
+                        <artifactId>aspectjtools</artifactId>
+                        <version>${aspectj.version}</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
-                    <showWeaveInfo>true</showWeaveInfo>
+                    <complianceLevel>${jdk.version}</complianceLevel>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
                 </configuration>
                 <executions>
                     <execution>
@@ -90,7 +97,7 @@
                         <Export-Package>org.apache.shiro.aspectj*;version=${project.version}</Export-Package>
                         <Import-Package>
                             org.apache.shiro*;version="${shiro.osgi.importRange}",
-                            org.aspectj*;version="[1.6.0, 2.0.0)",
+                            org.aspectj*;version="[1.8.0, 2.0.0)",
                             *
                         </Import-Package>
                     </instructions>

--- a/support/cas/pom.xml
+++ b/support/cas/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.jasig.cas.client</groupId>
             <artifactId>cas-client-core</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <!-- for Optional SAML ticket validation: -->

--- a/support/cas/src/main/java/org/apache/shiro/cas/CasRealm.java
+++ b/support/cas/src/main/java/org/apache/shiro/cas/CasRealm.java
@@ -30,7 +30,11 @@ import org.apache.shiro.subject.SimplePrincipalCollection;
 import org.apache.shiro.util.CollectionUtils;
 import org.apache.shiro.util.StringUtils;
 import org.jasig.cas.client.authentication.AttributePrincipal;
-import org.jasig.cas.client.validation.*;
+import org.jasig.cas.client.validation.Assertion;
+import org.jasig.cas.client.validation.Cas20ServiceTicketValidator;
+import org.jasig.cas.client.validation.Saml11TicketValidator;
+import org.jasig.cas.client.validation.TicketValidationException;
+import org.jasig.cas.client.validation.TicketValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +58,9 @@ import java.util.Map;
  * to the attributes previously retrieved).
  *
  * @since 1.2
+ * @deprecated since 2.0 if favor of the {@link org.apache.shiro.realm.AccountStoreRealm} configured with an CAS-specific {@link org.apache.shiro.account.AccountStore AccountStore}.
  */
+@Deprecated
 public class CasRealm extends AuthorizingRealm {
 
     // default name of the CAS attribute for remember me authentication (CAS 3.4.10+)

--- a/support/openid4j/src/main/java/org/apache/shiro/openid4j/realm/RelyingPartyRealm.java
+++ b/support/openid4j/src/main/java/org/apache/shiro/openid4j/realm/RelyingPartyRealm.java
@@ -29,7 +29,9 @@ import org.apache.shiro.realm.AuthenticatingRealm;
  * (client) to an OpenId Provider (server).
  *
  * @since 1.2
+ * @deprecated since 2.0 if favor of the {@link org.apache.shiro.realm.AccountStoreRealm} configured with an OpenId-specific {@link org.apache.shiro.account.AccountStore AccountStore}.
  */
+@Deprecated
 public class RelyingPartyRealm extends AuthenticatingRealm {
 
     private OpenIdService openIdService;


### PR DESCRIPTION
Because of  Stormpath Joins Forces With Okta. New user of Shiro cannot create new Stormpath  account that they cannot follow up the web demo. So the step-by-step demo using Stormpath account should switch to another platform. Pls kindly modify the Tutorial that we could catch up with this demo. Really thanks!