### PR TITLE
[SHIRO-458] Replaced string equals with internal method that does not leak time

### DIFF
--- a/core/src/main/java/org/apache/shiro/authc/credential/DefaultPasswordService.java
+++ b/core/src/main/java/org/apache/shiro/authc/credential/DefaultPasswordService.java
@@ -94,7 +94,26 @@ public class DefaultPasswordService implements HashingPasswordService {
 
         Hash computed = this.hashService.computeHash(request);
 
-        return saved.equals(computed);
+        return constantEquals(saved.toString(), computed.toString());
+    }
+
+    private boolean constantEquals(String savedHash, String computedHash) {
+
+        int result = 0;
+        boolean equals;
+        byte [] savedHashByteArray = savedHash.getBytes();
+        byte [] computedHashByteArray = computedHash.getBytes();
+
+        if(savedHashByteArray.length != computedHashByteArray.length){
+            return false;
+        } else {
+            for(int index = 0; index < savedHashByteArray.length; index++){
+                result |= savedHashByteArray[index] ^ computedHashByteArray[index];
+            }
+            equals = (result == 0);
+        }
+
+        return equals;
     }
 
     protected void checkHashFormatDurability() {


### PR DESCRIPTION
Followed the steps as described in the ticket https://issues.apache.org/jira/browse/SHIRO-458
Replaced the string equals with an internal equals method.
I ran the unit tests and they have all passed