### PR TITLE
FormAuthenticationFilter capacity limit in same production environments

### DIFF
--- a/web/src/main/java/org/apache/shiro/web/filter/authc/FormAuthenticationFilter.java
+++ b/web/src/main/java/org/apache/shiro/web/filter/authc/FormAuthenticationFilter.java
@@ -165,7 +165,7 @@ public class FormAuthenticationFilter extends AuthenticatingFilter {
                         "Authentication url [" + getLoginUrl() + "]");
             }
 
-            saveRequestAndRedirectToLogin(request, response);
+            saveRequestAndRedirectToLogin(request, response, null, false);
             return false;
         }
     }

--- a/web/src/main/java/org/apache/shiro/web/filter/authc/FormAuthenticationFilter.java
+++ b/web/src/main/java/org/apache/shiro/web/filter/authc/FormAuthenticationFilter.java
@@ -165,7 +165,7 @@ public class FormAuthenticationFilter extends AuthenticatingFilter {
                         "Authentication url [" + getLoginUrl() + "]");
             }
 
-            saveRequestAndRedirectToLogin(request, response, null, false);
+            saveRequestAndRedirectToLogin(request, response, null, true);
             return false;
         }
     }
@@ -203,7 +203,7 @@ public class FormAuthenticationFilter extends AuthenticatingFilter {
     protected boolean onLoginFailure(AuthenticationToken token, AuthenticationException e,
                                      ServletRequest request, ServletResponse response) {
         if (log.isDebugEnabled()) {
-            log.debug( "Authentication exception", e );
+            log.debug("Authentication exception", e);
         }
         setFailureAttribute(request, e);
         //login failed, let request continue back to the login page:


### PR DESCRIPTION
when our application was runing behind a nginx proxy. The request context was different with tomcat's context, for example my nginx proxy configuare is something like: 
 location ^~ /
        {
            proxy_pass http://MyTomcatServer/tomcatContext/;
        }
the session will lost because of cookie path change. though I know I can use proxy_cookie_path to change the cookie' path, I found it's still very useful when my class extend the FormAuthenticationFilter class. so I 
think it's betther to  provide two functions that are  very useful when your application running behind a proxy server which has  different context,  also very useful for subclasses pass parameters to the login page. 
How do you think?