### PR TITLE
[SHIRO-668] Catch unexpected errors which can lead to oom

### DIFF
--- a/core/src/main/java/org/apache/shiro/session/mgt/ExecutorServiceSessionValidationScheduler.java
+++ b/core/src/main/java/org/apache/shiro/session/mgt/ExecutorServiceSessionValidationScheduler.java
@@ -111,12 +111,16 @@ public class ExecutorServiceSessionValidationScheduler implements SessionValidat
         if (log.isDebugEnabled()) {
             log.debug("Executing session validation...");
         }
-        long startTime = System.currentTimeMillis();
-        this.sessionManager.validateSessions();
-        long stopTime = System.currentTimeMillis();
-        if (log.isDebugEnabled()) {
-            log.debug("Session validation completed successfully in " + (stopTime - startTime) + " milliseconds.");
-        }
+		try{
+			long startTime = System.currentTimeMillis();
+			this.sessionManager.validateSessions();
+			long stopTime = System.currentTimeMillis();
+			if (log.isDebugEnabled()) {
+				log.debug("Session validation completed successfully in " + (stopTime - startTime) + " milliseconds.");
+			}
+		}catch(Throwable e){
+			log.error("Session validation failed: " , e);
+		}
     }
 
     public void disableSessionValidation() {


### PR DESCRIPTION
Unexpected errors in the "run" method of the validation ExecutorServiceSessionValidationScheduler can kill the validation thread an it will not be executed anymore (see [StackOverflow](https://stackoverflow.com/questions/6494557/why-does-a-scheduledexecutorservice-not-run-a-task-again-after-an-exception-is-t).) This can lead to OOM's through too much sessions and can be a security risk by never ending sessions.
Catching "Throwable" is not the cleanest solution but it garant that the thread will be executed in the future.