### PR TITLE
shiro-guice depends on commons-beanutils

### DIFF
--- a/support/guice/pom.xml
+++ b/support/guice/pom.xml
@@ -55,6 +55,10 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>


### PR DESCRIPTION
shiro-guice has a direct dependency on commons-beanutils (via `ShiroModule` -> `BeanTypeListener.beanUtilsBean`), would be nice to declare that fact properly.