### PR TITLE
Fix for SHIRO-621: REST filter bypassing matched path

### DIFF
--- a/support/guice/pom.xml
+++ b/support/guice/pom.xml
@@ -29,6 +29,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shiro-guice</artifactId>
     <name>Apache Shiro :: Support :: Guice</name>
+    <version>1.4.0-ittiaminsite</version>
     <packaging>bundle</packaging>
 
     <dependencies>

--- a/support/guice/src/main/java/org/apache/shiro/guice/web/ShiroWebModule.java
+++ b/support/guice/src/main/java/org/apache/shiro/guice/web/ShiroWebModule.java
@@ -158,7 +158,8 @@ public abstract class ShiroWebModule extends ShiroModule {
 
                 // initialize key in filterToPathToConfig, if it doesn't exist
                 if (filterToPathToConfig.get(key) == null) {
-                    filterToPathToConfig.put((key), new HashMap<String, String>());
+                	// Fix for SHIRO-621: REST filter bypassing matched path
+                    filterToPathToConfig.put((key), new LinkedHashMap<String, String>());
                 }
                 // now set the value
                 filterToPathToConfig.get(key).put(path, config);


### PR DESCRIPTION
Use LinkedHashMap to maintain order of path to config map in filter chain in ShiroWebModule.