### PR TITLE
Fix Hasher's help output.

### DIFF
--- a/tools/hasher/src/main/java/org/apache/shiro/tools/hasher/Hasher.java
+++ b/tools/hasher/src/main/java/org/apache/shiro/tools/hasher/Hasher.java
@@ -382,16 +382,15 @@ public final class Hasher {
                 "\n\n" +
                 "Generating a salt:" +
                 "\n\n" +
-                "Use the -sg/--saltgenerated option if you don't want to specify a salt,\n" +
+                "Use the -gs/--gensalt option if you don't want to specify a salt,\n" +
                 "but want a strong random salt to be generated and used during hashing.\n" +
                 "The generated salt size defaults to 128 bits.  You may specify\n" +
-                "a different size by using the -sgs/--saltgeneratedsize option followed by\n" +
+                "a different size by using the -gss/--gensaltsize option followed by\n" +
                 "a positive integer (size is in bits, not bytes)." +
                 "\n\n" +
-                "Because a salt must be specified if computing the\n" +
-                "hash later, generated salts will be printed, defaulting to base64\n" +
-                "encoding.  If you prefer to use hex encoding, additionally use the\n" +
-                "-sgh/--saltgeneratedhex option." +
+                "Because a salt must be specified if computing the hash later,\n" +
+                "generated salts are only useful with the shiro1 output format;\n" +
+                "the other formats do not include the generated salt." +
                 "\n\n" +
                 "Specifying a private salt:" +
                 "\n\n" +


### PR DESCRIPTION
The options for controlling the generated public salt were all
incorrectly documented.