### PR TITLE
SHIRO-646 Allow a DelegatingSubject to login Statelessly on a DefaultWebSecurityManager

### DIFF
--- a/web/src/main/java/org/apache/shiro/web/mgt/DefaultWebSecurityManager.java
+++ b/web/src/main/java/org/apache/shiro/web/mgt/DefaultWebSecurityManager.java
@@ -69,11 +69,13 @@ public class DefaultWebSecurityManager extends DefaultSecurityManager implements
 
     public DefaultWebSecurityManager() {
         super();
-        ((DefaultSubjectDAO) this.subjectDAO).setSessionStorageEvaluator(new DefaultWebSessionStorageEvaluator());
+        DefaultWebSessionStorageEvaluator webEvalutator = new DefaultWebSessionStorageEvaluator();  
+        ((DefaultSubjectDAO) this.subjectDAO).setSessionStorageEvaluator(webEvalutator);
         this.sessionMode = HTTP_SESSION_MODE;
         setSubjectFactory(new DefaultWebSubjectFactory());
         setRememberMeManager(new CookieRememberMeManager());
         setSessionManager(new ServletContainerSessionManager());
+        webEvalutator.setSessionManager(getSessionManager());
     }
 
     @SuppressWarnings({"UnusedDeclaration"})

--- a/web/src/main/java/org/apache/shiro/web/mgt/DefaultWebSubjectFactory.java
+++ b/web/src/main/java/org/apache/shiro/web/mgt/DefaultWebSubjectFactory.java
@@ -29,6 +29,7 @@ import org.apache.shiro.web.subject.support.WebDelegatingSubject;
 
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import org.apache.shiro.web.subject.WebSubject;
 
 /**
  * A {@code SubjectFactory} implementation that creates {@link WebDelegatingSubject} instances.
@@ -46,7 +47,11 @@ public class DefaultWebSubjectFactory extends DefaultSubjectFactory {
     }
 
     public Subject createSubject(SubjectContext context) {
-        if (!(context instanceof WebSubjectContext)) {
+        //SHIRO-646
+        //Check if the existing subject is NOT a WebSubject. If it isn't, then call super.createSubject instead.
+        //Creating a WebSubject from a non-web Subject will cause the ServletRequest and ServletResponse to be null, which wil fail when creating a session.
+        boolean isNotBasedOnWebSubject = context.getSubject() != null && !(context.getSubject() instanceof WebSubject);
+        if (!(context instanceof WebSubjectContext) || isNotBasedOnWebSubject) {
             return super.createSubject(context);
         }
         WebSubjectContext wsc = (WebSubjectContext) context;

--- a/web/src/test/java/org/apache/shiro/web/mgt/DefaultWebSecurityManagerTest.java
+++ b/web/src/test/java/org/apache/shiro/web/mgt/DefaultWebSecurityManagerTest.java
@@ -234,5 +234,5 @@ public class DefaultWebSecurityManagerTest extends AbstractWebSecurityManagerTes
         assertNotNull(subject);
         assertEquals("user1", subject.getPrincipal());
     }
-
+    
 }

--- a/web/src/test/java/org/apache/shiro/web/mgt/DefaultWebSecurityManagerTest.java
+++ b/web/src/test/java/org/apache/shiro/web/mgt/DefaultWebSecurityManagerTest.java
@@ -234,5 +234,5 @@ public class DefaultWebSecurityManagerTest extends AbstractWebSecurityManagerTes
         assertNotNull(subject);
         assertEquals("user1", subject.getPrincipal());
     }
-    
+
 }

--- a/web/src/test/java/org/apache/shiro/web/mgt/NonIniWebSecurityManagerTest.java
+++ b/web/src/test/java/org/apache/shiro/web/mgt/NonIniWebSecurityManagerTest.java
@@ -13,10 +13,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-/**
- *
- * @author mnn
- */
 public class NonIniWebSecurityManagerTest extends AbstractWebSecurityManagerTest {
     
     private DefaultWebSecurityManager sm;

--- a/web/src/test/java/org/apache/shiro/web/mgt/NonIniWebSecurityManagerTest.java
+++ b/web/src/test/java/org/apache/shiro/web/mgt/NonIniWebSecurityManagerTest.java
@@ -1,0 +1,47 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.apache.shiro.web.mgt;
+
+import org.apache.shiro.authc.UsernamePasswordToken;
+import org.apache.shiro.config.Ini;
+import org.apache.shiro.realm.text.IniRealm;
+import org.apache.shiro.subject.Subject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ * @author mnn
+ */
+public class NonIniWebSecurityManagerTest extends AbstractWebSecurityManagerTest {
+    
+    private DefaultWebSecurityManager sm;
+    
+    @Before
+    public void setup() {
+        sm = new DefaultWebSecurityManager();
+        Ini ini = new Ini();
+        Ini.Section section = ini.addSection(IniRealm.USERS_SECTION_NAME);
+        section.put("lonestarr", "vespa");
+        sm.setRealm(new IniRealm(ini));
+    }
+
+    @After
+    public void tearDown() {
+        sm.destroy();
+        super.tearDown();
+    }
+    
+    @Test
+    public void testLoginNonWebSubject(){
+        Subject.Builder builder = new Subject.Builder(sm);
+        Subject subject = builder.buildSubject();
+        subject.login(new UsernamePasswordToken("lonestarr", "vespa"));
+        
+    }
+    
+}


### PR DESCRIPTION
Added: Test to login a DelegatingSubject on a programatically created DefaultWebSecurityManager
Fixed: DefaultWebSessionStorageEvaluator now has a SessionManager set when a DefaultWebSecurityManager is created though its noargs constructor.
Fixed: DefaultWebSubjectFactory now checks if its existing subject is indeed a WebSubject, and if not delegates to its supermethod. This avoids WebSubjects with null ServletRequest/Response.
