### PR TITLE
[SHIRO-457] Set SecurityManager in createSubject()

### DIFF
--- a/core/src/main/java/org/apache/shiro/mgt/DefaultSecurityManager.java
+++ b/core/src/main/java/org/apache/shiro/mgt/DefaultSecurityManager.java
@@ -181,6 +181,7 @@ public class DefaultSecurityManager extends SessionsSecurityManager {
         context.setAuthenticated(true);
         context.setAuthenticationToken(token);
         context.setAuthenticationInfo(info);
+        context.setSecurityManager(this);
         if (existing != null) {
             context.setSubject(existing);
         }


### PR DESCRIPTION
When one does not use a static SecurityManager an exception is thrown everytime a new (unauthenticated) subject successfully logs in. See the associated JIRA issue https://issues.apache.org/jira/browse/SHIRO-457