### PR TITLE
[SHIRO-687] Adding Spring's Filters to ShiroFilterFactorBean when using Java config

### DIFF
--- a/support/spring/pom.xml
+++ b/support/spring/pom.xml
@@ -72,6 +72,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-aspectj</artifactId>
             <scope>test</scope>

--- a/support/spring/src/main/java/org/apache/shiro/spring/web/config/AbstractShiroWebFilterConfiguration.java
+++ b/support/spring/src/main/java/org/apache/shiro/spring/web/config/AbstractShiroWebFilterConfiguration.java
@@ -24,6 +24,9 @@ import org.apache.shiro.spring.web.ShiroFilterFactoryBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
+import javax.servlet.Filter;
+import java.util.Map;
+
 /**
  * @since 1.4.0
  */
@@ -34,6 +37,9 @@ public class AbstractShiroWebFilterConfiguration {
 
     @Autowired
     protected ShiroFilterChainDefinition shiroFilterChainDefinition;
+
+    @Autowired
+    protected Map<String, Filter> filterMap;
 
     @Value("#{ @environment['shiro.loginUrl'] ?: '/login.jsp' }")
     protected String loginUrl;
@@ -53,6 +59,7 @@ public class AbstractShiroWebFilterConfiguration {
 
         filterFactoryBean.setSecurityManager(securityManager);
         filterFactoryBean.setFilterChainDefinitionMap(shiroFilterChainDefinition.getFilterChainMap());
+        filterFactoryBean.setFilters(filterMap);
 
         return filterFactoryBean;
     }

--- a/support/spring/src/test/groovy/org/apache/shiro/spring/config/ShiroWebFilterConfigurationTest.groovy
+++ b/support/spring/src/test/groovy/org/apache/shiro/spring/config/ShiroWebFilterConfigurationTest.groovy
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.shiro.spring.config
 
 import org.apache.shiro.mgt.SecurityManager

--- a/support/spring/src/test/groovy/org/apache/shiro/spring/config/ShiroWebFilterConfigurationTest.groovy
+++ b/support/spring/src/test/groovy/org/apache/shiro/spring/config/ShiroWebFilterConfigurationTest.groovy
@@ -1,0 +1,82 @@
+package org.apache.shiro.spring.config
+
+import org.apache.shiro.mgt.SecurityManager
+import org.apache.shiro.spring.testconfig.RealmTestConfiguration
+import org.apache.shiro.spring.web.ShiroFilterFactoryBean
+import org.apache.shiro.spring.web.config.DefaultShiroFilterChainDefinition
+import org.apache.shiro.spring.web.config.ShiroFilterChainDefinition
+import org.apache.shiro.spring.web.config.ShiroWebFilterConfiguration
+import org.apache.shiro.web.filter.mgt.FilterChainManager
+import org.junit.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests
+import org.springframework.test.context.web.WebAppConfiguration
+
+import javax.servlet.Filter
+import javax.servlet.FilterChain
+import javax.servlet.FilterConfig
+import javax.servlet.ServletException
+import javax.servlet.ServletRequest
+import javax.servlet.ServletResponse
+
+import static org.hamcrest.Matchers.contains
+import static org.hamcrest.Matchers.instanceOf
+import static org.hamcrest.Matchers.notNullValue
+import static org.hamcrest.MatcherAssert.assertThat
+
+/**
+ * Test ShiroWebFilterConfiguration creates a ShiroFilterFactoryBean that contains Servlet filters that are available for injection.
+ */
+@WebAppConfiguration
+@ContextConfiguration(classes = [RealmTestConfiguration, FilterConfiguration, ShiroConfiguration, ShiroWebFilterConfiguration])
+class ShiroWebFilterConfigurationTest extends AbstractJUnit4SpringContextTests {
+
+    @Autowired
+    private SecurityManager securityManager
+
+    @Autowired
+    private ShiroFilterFactoryBean shiroFilterFactoryBean
+
+    @Test
+    void testShiroFilterFactoryBeanContainsSpringFilters() {
+
+        assertThat shiroFilterFactoryBean, notNullValue()
+
+        // create the filter chain manager
+        FilterChainManager filterChainManager = shiroFilterFactoryBean.createFilterChainManager()
+        // lookup the chain by name
+        assertThat filterChainManager.getChain("/test-me"), contains(instanceOf(ExpectedTestFilter))
+    }
+
+    @Configuration
+    static class FilterConfiguration {
+
+        // random custom filter, which will be looked up via the shiroFilterFactoryBean
+        @Bean
+        Filter testFilter() {
+            return new ExpectedTestFilter()
+        }
+
+        @Bean
+        ShiroFilterChainDefinition shiroFilterChainDefinition() {
+            DefaultShiroFilterChainDefinition chainDefinition = new DefaultShiroFilterChainDefinition()
+            chainDefinition.addPathDefinition("/test-me", "testFilter") // def matches the bean name
+            chainDefinition.addPathDefinition("/**", "authc")
+            return chainDefinition
+        }
+    }
+
+    static class ExpectedTestFilter implements Filter {
+        @Override
+        void init(FilterConfig filterConfig) throws ServletException {}
+
+        @Override
+        void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {}
+
+        @Override
+        void destroy() {}
+    }
+}


### PR DESCRIPTION
In the days of XML this was defined, but was missed when we ported it to Java config

NOTE: This still needs tests. I put this in a PR so we wouldn't forget, but this was found based on a question from [StackOverflow](https://stackoverflow.com/questions/51552021/adding-custom-filter-apache-shiro-spring-boot).