### PR TITLE
[SHIRO-661] Add check for the principal of subject whether is null

### DIFF
--- a/core/src/main/java/org/apache/shiro/subject/support/DelegatingSubject.java
+++ b/core/src/main/java/org/apache/shiro/subject/support/DelegatingSubject.java
@@ -294,7 +294,7 @@ public class DelegatingSubject implements Subject {
     }
 
     public boolean isAuthenticated() {
-        return authenticated;
+        return authenticated && hasPrincipals();
     }
 
     public boolean isRemembered() {

--- a/web/src/main/java/org/apache/shiro/web/filter/authc/AuthenticationFilter.java
+++ b/web/src/main/java/org/apache/shiro/web/filter/authc/AuthenticationFilter.java
@@ -78,7 +78,7 @@ public abstract class AuthenticationFilter extends AccessControlFilter {
      */
     protected boolean isAccessAllowed(ServletRequest request, ServletResponse response, Object mappedValue) {
         Subject subject = getSubject(request, response);
-        return subject.isAuthenticated();
+        return subject.isAuthenticated() && subject.getPrincipal() != null;
     }
 
     /**


### PR DESCRIPTION
When session is based on servlet container(such as tomcat),if the subject is authenticated，the session will contains `AUTHENTICATED_SESSION_KEY` and `PRINCIPALS_SESSION_KEY`。
When servlet container closed, it may will be persist session.
But if the principal can not be serializable, it will not be persisted; when server restart, session will only contains `AUTHENTICATED_SESSION_KEY` info ,the `PRINCIPALS_SESSION_KEY` will be lost, 
it means the subject is authenticated, but the subject does not has principal。If the user code is 
```
User u = subject.getPrincipal();
// because the u if null, it will be npe
u.getName();
```
Recently, my project has happened such case, so I think add check for  principal of subject whether is null can make application more powerful.
