### PR TITLE
SHIRO-655 Bump commons-configuration2 dependency version to avoid OSGi…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -781,7 +781,7 @@
                 <!-- optional dep for the reflection builder -->
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-configuration2</artifactId>
-                <version>2.1</version>
+                <version>2.2</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-logging</groupId>


### PR DESCRIPTION
… runtime dependency to springframework

I've verified that this was sufficient to remove the springframework runtime depenency from a project using shiro 1.4.x