### PR TITLE
SHIRO-658 Add workaround for openjdk-8 maven build issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -383,6 +383,7 @@
                 <version>2.19.1</version>
                 <configuration>
                     <printSummary>true</printSummary>
+                    <useSystemClassLoader>false</useSystemClassLoader>
                 </configuration>
             </plugin>
             <plugin>
@@ -390,6 +391,7 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>2.19.1</version>
                 <configuration>
+                    <useSystemClassLoader>false</useSystemClassLoader>
                     <includes>
                         <include>**/*IT.java</include>
                         <include>**/*IT.groovy</include>


### PR DESCRIPTION
This workaround makes shiro build on the current debian stable.

The workaround comes from here https://stackoverflow.com/a/53096179