### PR TITLE
[SHIRO-662] Constant Name Change in AuthenticationRealm

### DIFF
--- a/core/src/main/java/org/apache/shiro/realm/AuthenticatingRealm.java
+++ b/core/src/main/java/org/apache/shiro/realm/AuthenticatingRealm.java
@@ -123,7 +123,7 @@ public abstract class AuthenticatingRealm extends CachingRealm implements Initia
      *
      * @since 1.2
      */
-    private static final String DEFAULT_AUTHORIZATION_CACHE_SUFFIX = ".authenticationCache";
+    private static final String DEFAULT_AUTHENTICATION_CACHE_SUFFIX = ".authenticationCache";
 
     /**
      * Credentials matcher used to determine if the provided credentials match the credentials stored in the data store.
@@ -166,7 +166,7 @@ public abstract class AuthenticatingRealm extends CachingRealm implements Initia
         this.authenticationCachingEnabled = false;
 
         int instanceNumber = INSTANCE_COUNT.getAndIncrement();
-        this.authenticationCacheName = getClass().getName() + DEFAULT_AUTHORIZATION_CACHE_SUFFIX;
+        this.authenticationCacheName = getClass().getName() + DEFAULT_AUTHENTICATION_CACHE_SUFFIX;
         if (instanceNumber > 0) {
             this.authenticationCacheName = this.authenticationCacheName + "." + instanceNumber;
         }
@@ -346,7 +346,7 @@ public abstract class AuthenticatingRealm extends CachingRealm implements Initia
         if (authcCacheName != null && authcCacheName.startsWith(getClass().getName())) {
             //get rid of the default heuristically-created cache name.  Create a more meaningful one
             //based on the application-unique Realm name:
-            this.authenticationCacheName = name + DEFAULT_AUTHORIZATION_CACHE_SUFFIX;
+            this.authenticationCacheName = name + DEFAULT_AUTHENTICATION_CACHE_SUFFIX;
         }
     }
 

--- a/core/src/test/groovy/org/apache/shiro/realm/AuthenticatingRealmTest.groovy
+++ b/core/src/test/groovy/org/apache/shiro/realm/AuthenticatingRealmTest.groovy
@@ -38,7 +38,7 @@ class AuthenticatingRealmTest extends GroovyTestCase {
         realm.init()
 
         assertEquals name, realm.name
-        assertEquals name + AuthenticatingRealm.DEFAULT_AUTHORIZATION_CACHE_SUFFIX, realm.authenticationCacheName
+        assertEquals name + AuthenticatingRealm.DEFAULT_AUTHENTICATION_CACHE_SUFFIX, realm.authenticationCacheName
 
         realm.authenticationCacheName = "bar"
 
@@ -210,7 +210,7 @@ class AuthenticatingRealmTest extends GroovyTestCase {
     void testLogoutWithAuthenticationCachingEnabled() {
 
         def realmName = "testRealm"
-        def authcCacheName = realmName + AuthenticatingRealm.DEFAULT_AUTHORIZATION_CACHE_SUFFIX
+        def authcCacheName = realmName + AuthenticatingRealm.DEFAULT_AUTHENTICATION_CACHE_SUFFIX
         def username = "foo"
 
         def cacheManager = createStrictMock(CacheManager)


### PR DESCRIPTION
Supercedes https://github.com/apache/shiro/pull/69

This fix the failing test.