### PR TITLE
SHIRO-695 - Update Hazelcast

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
              modules' OSGi metadata: -->
         <ehcache.version>2.6.11</ehcache.version>
         <!-- Don't change this version without also changing the shiro-hazelcast and shiro-features OSGi metadata: -->
-        <hazelcast.version>3.7.2</hazelcast.version>
+        <hazelcast.version>3.12</hazelcast.version>
         <hsqldb.version>1.8.0.7</hsqldb.version>
         <jdk.version>1.8</jdk.version>
         <jetty.version>9.3.0.M1</jetty.version>

--- a/support/hazelcast/pom.xml
+++ b/support/hazelcast/pom.xml
@@ -32,7 +32,7 @@
     <packaging>bundle</packaging>
 
     <properties>
-        <hazelcast.osgi.importRange>[2.4, 4)</hazelcast.osgi.importRange>
+        <hazelcast.osgi.importRange>[3, 4)</hazelcast.osgi.importRange>
     </properties>
 
     <dependencies>


### PR DESCRIPTION


Hazelcast should be updated as it carries a CVE:

hazelcast-3.7.2.jar (pkg:maven/com.hazelcast/hazelcast@3.7.2, cpe:2.3:a:hazelcast:hazelcast:3.7.2:::::::*) : CVE-2016-10750
