### PR TITLE
Remove old JSTL jars

### DIFF
--- a/integration-tests/guice3/pom.xml
+++ b/integration-tests/guice3/pom.xml
@@ -46,9 +46,14 @@
 
 	<dependencies>
 	    <dependency>
-	        <groupId>javax.servlet</groupId>
-	        <artifactId>jstl</artifactId>
-			<scope>compile</scope>
+		<groupId>org.apache.taglibs</groupId>
+		<artifactId>taglibs-standard-spec</artifactId>
+		<scope>compile</scope>
+	    </dependency>
+	    <dependency>
+	        <groupId>org.apache.taglibs</groupId>
+		<artifactId>taglibs-standard-impl</artifactId>
+		<scope>compile</scope>
 	    </dependency>
 	    <dependency>
 	        <groupId>javax.servlet</groupId>

--- a/integration-tests/guice4/pom.xml
+++ b/integration-tests/guice4/pom.xml
@@ -51,9 +51,14 @@
 
 	<dependencies>
 	    <dependency>
-	        <groupId>javax.servlet</groupId>
-	        <artifactId>jstl</artifactId>
-			<scope>compile</scope>
+		<groupId>org.apache.taglibs</groupId>
+		<artifactId>taglibs-standard-spec</artifactId>
+		<scope>compile</scope>
+	    </dependency>
+	    <dependency>
+		<groupId>org.apache.taglibs</groupId>
+		<artifactId>taglibs-standard-impl</artifactId>
+		<scope>compile</scope>
 	    </dependency>
 	    <dependency>
 	        <groupId>javax.servlet</groupId>

--- a/integration-tests/support/pom.xml
+++ b/integration-tests/support/pom.xml
@@ -32,9 +32,14 @@
 
 	<dependencies>
 	    <dependency>
-	        <groupId>javax.servlet</groupId>
-	        <artifactId>jstl</artifactId>
-			<scope>compile</scope>
+		<groupId>org.apache.taglibs</groupId>
+		<artifactId>taglibs-standard-spec</artifactId>
+		<scope>compile</scope>
+	    </dependency>
+	    <dependency>
+		<groupId>org.apache.taglibs</groupId>
+		<artifactId>taglibs-standard-impl</artifactId>
+		<scope>compile</scope>
 	    </dependency>
 	    <dependency>
 	        <groupId>javax.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <junit.version>4.12</junit.version>
         <junit.server.jetty.version>0.11.0</junit.server.jetty.version>
         <hibernate.version>5.4.3.Final</hibernate.version>
-        <taglib.standard.version>1.1.2</taglib.standard.version>
+        <taglibs.standard.version>1.2.5</taglibs.standard.version>
         <!-- so we can mock static methods in 3rd party libraries that sometimes don't use proper interfaces
              ahem, hazelcast, ahem... -->
         <powermock.version>2.0.2</powermock.version>
@@ -918,9 +918,15 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>jstl</artifactId>
-                <version>1.2</version>
+                <groupId>org.apache.taglibs</groupId>
+                <artifactId>taglibs-standard-spec</artifactId>
+                <version>${taglibs.standard.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.taglibs</groupId>
+                <artifactId>taglibs-standard-impl</artifactId>
+                <version>${taglibs.standard.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
@@ -1171,12 +1177,6 @@
                         <artifactId>commons-logging</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>taglibs</groupId>
-                <artifactId>standard</artifactId>
-                <version>${taglib.standard.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>com.github.mjeanroy</groupId>

--- a/samples/guice/pom.xml
+++ b/samples/guice/pom.xml
@@ -41,9 +41,14 @@
 
 	<dependencies>
 	    <dependency>
-	        <groupId>javax.servlet</groupId>
-	        <artifactId>jstl</artifactId>
-			<scope>compile</scope>
+		<groupId>org.apache.taglibs</groupId>
+		<artifactId>taglibs-standard-spec</artifactId>
+		<scope>compile</scope>
+	    </dependency>
+	    <dependency>
+		<groupId>org.apache.taglibs</groupId>
+		<artifactId>taglibs-standard-impl</artifactId>
+		<scope>compile</scope>
 	    </dependency>
 	    <dependency>
 	        <groupId>javax.servlet</groupId>

--- a/samples/servlet-plugin/pom.xml
+++ b/samples/servlet-plugin/pom.xml
@@ -63,8 +63,13 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>jstl</artifactId>
+            <groupId>org.apache.taglibs</groupId>
+            <artifactId>taglibs-standard-spec</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.taglibs</groupId>
+            <artifactId>taglibs-standard-impl</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/samples/spring-hibernate/pom.xml
+++ b/samples/spring-hibernate/pom.xml
@@ -120,8 +120,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>jstl</artifactId>
+            <groupId>org.apache.taglibs</groupId>
+            <artifactId>taglibs-standard-spec</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.taglibs</groupId>
+            <artifactId>taglibs-standard-impl</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/samples/spring-mvc/pom.xml
+++ b/samples/spring-mvc/pom.xml
@@ -154,8 +154,13 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>jstl</artifactId>
+            <groupId>org.apache.taglibs</groupId>
+            <artifactId>taglibs-standard-spec</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.taglibs</groupId>
+            <artifactId>taglibs-standard-impl</artifactId>
             <scope>runtime</scope>
         </dependency>
     </dependencies>

--- a/samples/web/pom.xml
+++ b/samples/web/pom.xml
@@ -63,8 +63,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>jstl</artifactId>
+            <groupId>org.apache.taglibs</groupId>
+            <artifactId>taglibs-standard-spec</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.taglibs</groupId>
+            <artifactId>taglibs-standard-impl</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -94,10 +99,6 @@
         <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>taglibs</groupId>
-            <artifactId>standard</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -42,8 +42,12 @@
             <artifactId>jsp-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>jstl</artifactId>
+            <groupId>org.apache.taglibs</groupId>
+            <artifactId>taglibs-standard-spec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.taglibs</groupId>
+            <artifactId>taglibs-standard-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>


### PR DESCRIPTION
Remove old JSTL jars and replace with up-to-date Apache version, which doesn't have a CVE associated with it.