### PR TITLE
[SHIRO-684] INI parser keeps escape characters in keys and values

### DIFF
--- a/config/core/src/main/java/org/apache/shiro/config/Ini.java
+++ b/config/core/src/main/java/org/apache/shiro/config/Ini.java
@@ -561,7 +561,7 @@ public class Ini implements Map<String, Ini.Section> {
         }
 
         private static boolean isCharEscaped(CharSequence s, int index) {
-            return index > 0 && s.charAt(index - 1) == ESCAPE_TOKEN;
+            return index > 0 && s.charAt(index) == ESCAPE_TOKEN;
         }
 
         //Protected to access in a test case - NOT considered part of Shiro's public API
@@ -581,13 +581,13 @@ public class Ini implements Map<String, Ini.Section> {
                 if (buildingKey) {
                     if (isKeyValueSeparatorChar(c) && !isCharEscaped(line, i)) {
                         buildingKey = false;//now start building the value
-                    } else {
+                    } else if (!isCharEscaped(line, i)){
                         keyBuffer.append(c);
                     }
                 } else {
                     if (valueBuffer.length() == 0 && isKeyValueSeparatorChar(c) && !isCharEscaped(line, i)) {
                         //swallow the separator chars before we start building the value
-                    } else {
+                    } else if (!isCharEscaped(line, i)){
                         valueBuffer.append(c);
                     }
                 }

--- a/config/core/src/test/groovy/org/apache/shiro/config/IniTest.groovy
+++ b/config/core/src/test/groovy/org/apache/shiro/config/IniTest.groovy
@@ -118,6 +118,26 @@ public class IniTest {
         kv = Ini.Section.splitKeyValue(test);
         assertEquals("Truth", kv[0]);
         assertEquals("Beauty", kv[1]);
+
+        test = "Tru\\th=Beauty";
+        kv = Ini.Section.splitKeyValue(test);
+        assertEquals("Truth", kv[0]);
+        assertEquals("Beauty", kv[1]);
+
+        test = "Truth\\=Beauty";
+        kv = Ini.Section.splitKeyValue(test);
+        assertEquals("Truth", kv[0]);
+        assertEquals("Beauty", kv[1]);
+
+        test = "Truth=Beau\\ty";
+        kv = Ini.Section.splitKeyValue(test);
+        assertEquals("Truth", kv[0]);
+        assertEquals("Beauty", kv[1]);
+
+        test = "Truth=Beauty\\";
+        kv = Ini.Section.splitKeyValue(test);
+        assertEquals("Truth", kv[0]);
+        assertEquals("Beauty", kv[1]);
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
When fixing this issue, I found a bug in the `isCharEscaped` method and the `index` usage.