### PR TITLE
Get the aspectj modules passing with JDK 11

### DIFF
--- a/samples/aspectj/pom.xml
+++ b/samples/aspectj/pom.xml
@@ -34,9 +34,14 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>com.nickwongdev</groupId>
+				<artifactId>aspectj-maven-plugin</artifactId>
+				<version>1.12.1</version>
+				<!-- Using a fork, until such time that the aspect-maven-plugin updates to support JDK 11 - https://github.com/mojohaus/aspectj-maven-plugin/pull/45
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>aspectj-maven-plugin</artifactId>
 				<version>1.11</version>
+				-->
 				<configuration>
 					<source>${jdk.version}</source>
 					<target>${jdk.version}</target>

--- a/support/aspectj/pom.xml
+++ b/support/aspectj/pom.xml
@@ -62,9 +62,14 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>com.nickwongdev</groupId>
+                <artifactId>aspectj-maven-plugin</artifactId>
+                <version>1.12.1</version>
+                <!-- Using a fork, until such time that the aspect-maven-plugin updates to support JDK 11 - https://github.com/mojohaus/aspectj-maven-plugin/pull/45
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
                 <version>1.11</version>
+                -->
                 <configuration>
                     <source>${jdk.version}</source>
                     <target>${jdk.version}</target>


### PR DESCRIPTION
The current aspectj maven plugin appears dead - so switch to use a fork which supports JDK 11