### PR TITLE
[SHIRO-735] Enable servlet async support.

### DIFF
--- a/support/servlet-plugin/src/main/resources/META-INF/web-fragment.xml
+++ b/support/servlet-plugin/src/main/resources/META-INF/web-fragment.xml
@@ -32,6 +32,7 @@
     <filter>
         <filter-name>ShiroFilter</filter-name>
         <filter-class>org.apache.shiro.web.servlet.ShiroFilter</filter-class>
+        <async-supported>true</async-supported>
     </filter>
 
     <filter-mapping>
@@ -41,6 +42,7 @@
         <dispatcher>FORWARD</dispatcher>
         <dispatcher>INCLUDE</dispatcher>
         <dispatcher>ERROR</dispatcher>
+        <dispatcher>ASYNC</dispatcher>
     </filter-mapping>
 
 </web-fragment>


### PR DESCRIPTION
Enables async support for use of `@Suspended AsyncResponse`. Some Application Servers, like Liberty Profile, will throw a NullPointerException without this commit.

Signed-off-by: Benjamin Marwell <bmarwell@gmail.com>