### PR TITLE
[SHIRO-742]fix throw exception when request uri is /

### DIFF
--- a/web/src/main/java/org/apache/shiro/web/filter/PathMatchingFilter.java
+++ b/web/src/main/java/org/apache/shiro/web/filter/PathMatchingFilter.java
@@ -123,10 +123,12 @@ public abstract class PathMatchingFilter extends AdviceFilter implements PathCon
      */
     protected boolean pathsMatch(String path, ServletRequest request) {
         String requestURI = getPathWithinApplication(request);
-        if (requestURI != null && requestURI.endsWith(DEFAULT_PATH_SEPARATOR)) {
+        if (requestURI != null && !DEFAULT_PATH_SEPARATOR.equals(requestURI)
+                && requestURI.endsWith(DEFAULT_PATH_SEPARATOR)) {
             requestURI = requestURI.substring(0, requestURI.length() - 1);
         }
-        if (path != null && path.endsWith(DEFAULT_PATH_SEPARATOR)) {
+        if (path != null && !DEFAULT_PATH_SEPARATOR.equals(path)
+                && path.endsWith(DEFAULT_PATH_SEPARATOR)) {
             path = path.substring(0, path.length() - 1);
         }
         log.trace("Attempting to match pattern '{}' with current requestURI '{}'...", path, Encode.forHtml(requestURI));

--- a/web/src/main/java/org/apache/shiro/web/filter/mgt/PathMatchingFilterChainResolver.java
+++ b/web/src/main/java/org/apache/shiro/web/filter/mgt/PathMatchingFilterChainResolver.java
@@ -105,7 +105,8 @@ public class PathMatchingFilterChainResolver implements FilterChainResolver {
         // in spring web, the requestURI "/resource/menus" ---- "resource/menus/" bose can access the resource
         // but the pathPattern match "/resource/menus" can not match "resource/menus/"
         // user can use requestURI + "/" to simply bypassed chain filter, to bypassed shiro protect
-        if(requestURI != null && requestURI.endsWith(DEFAULT_PATH_SEPARATOR)) {
+        if(requestURI != null && !DEFAULT_PATH_SEPARATOR.equals(requestURI)
+                && requestURI.endsWith(DEFAULT_PATH_SEPARATOR)) {
             requestURI = requestURI.substring(0, requestURI.length() - 1);
         }
 
@@ -113,7 +114,8 @@ public class PathMatchingFilterChainResolver implements FilterChainResolver {
         //the 'chain names' in this implementation are actually path patterns defined by the user.  We just use them
         //as the chain name for the FilterChainManager's requirements
         for (String pathPattern : filterChainManager.getChainNames()) {
-            if (pathPattern != null && pathPattern.endsWith(DEFAULT_PATH_SEPARATOR)) {
+            if (pathPattern != null && !DEFAULT_PATH_SEPARATOR.equals(pathPattern)
+                    && pathPattern.endsWith(DEFAULT_PATH_SEPARATOR)) {
                 pathPattern = pathPattern.substring(0, pathPattern.length() - 1);
             }
 

--- a/web/src/test/java/org/apache/shiro/web/filter/PathMatchingFilterTest.java
+++ b/web/src/test/java/org/apache/shiro/web/filter/PathMatchingFilterTest.java
@@ -122,6 +122,20 @@ public class PathMatchingFilterTest {
     }
 
     /**
+     * Test asserting <a href="https://issues.apache.org/jira/browse/SHIRO-742">SHIRO-742<a/>.
+     */
+    @Test
+    public void testPathMatchEqualUrlSeparatorEnabled() {
+        expect(request.getContextPath()).andReturn(CONTEXT_PATH).anyTimes();
+        expect(request.getRequestURI()).andReturn("/").anyTimes();
+        replay(request);
+
+        boolean matchEnabled = filter.pathsMatch("/", request);
+        assertTrue("PathMatch can match URL end with Separator", matchEnabled);
+        verify(request);
+    }
+
+    /**
      * Test asserting <a href="https://issues.apache.org/jira/browse/SHIRO-682">SHIRO-682<a/>.
      */
     @Test

--- a/web/src/test/java/org/apache/shiro/web/filter/mgt/PathMatchingFilterChainResolverTest.java
+++ b/web/src/test/java/org/apache/shiro/web/filter/mgt/PathMatchingFilterChainResolverTest.java
@@ -187,6 +187,28 @@ public class PathMatchingFilterChainResolverTest extends WebTest {
     }
 
     /**
+     * Test asserting <a href="https://issues.apache.org/jira/browse/SHIRO-742">SHIRO-742<a/>.
+     */
+    @Test
+    public void testGetChainEqualUrlSeparator() {
+        HttpServletRequest request = createNiceMock(HttpServletRequest.class);
+        HttpServletResponse response = createNiceMock(HttpServletResponse.class);
+        FilterChain chain = createNiceMock(FilterChain.class);
+
+        //ensure at least one chain is defined:
+        resolver.getFilterChainManager().addToChain("/", "authcBasic");
+
+        expect(request.getAttribute(WebUtils.INCLUDE_CONTEXT_PATH_ATTRIBUTE)).andReturn(null).anyTimes();
+        expect(request.getContextPath()).andReturn("");
+        expect(request.getRequestURI()).andReturn("/");
+        replay(request);
+
+        FilterChain resolved = resolver.getChain(request, response, chain);
+        assertNotNull(resolved);
+        verify(request);
+    }
+
+    /**
      * Test asserting <a href="https://issues.apache.org/jira/browse/SHIRO-682">SHIRO-682<a/>.
      */
     @Test


### PR DESCRIPTION
this bug due to my pr  [SHIRO-682 fix the potential threat when use "uri = uri + '/' " to bypassed shiro](https://github.com/apache/shiro/pull/127) in 1.5, sorry 

as the @jaynlau [comment](https://github.com/apache/shiro/pull/181)
under is @jaynlau report  
````
Can not get the NamedFilterList when request uri is "/".

java.lang.IllegalArgumentException: There is no configured chain under the name/key [].
	at org.apache.shiro.web.filter.mgt.DefaultFilterChainManager.proxy(DefaultFilterChainManager.java:322) ~[shiro-web-1.5.0.jar:1.5.0]
	at org.apache.shiro.web.filter.mgt.PathMatchingFilterChainResolver.getChain(PathMatchingFilterChainResolver.java:126) ~[shiro-web-1.5.0.jar:1.5.0]
	at org.apache.shiro.web.servlet.AbstractShiroFilter.getExecutionChain(AbstractShiroFilter.java:415) ~[shiro-web-1.5.0.jar:1.5.0]
	at org.apache.shiro.web.servlet.AbstractShiroFilter.executeChain(AbstractShiroFilter.java:448) ~[shiro-web-1.5.0.jar:1.5.0]
	at org.apache.shiro.web.servlet.AbstractShiroFilter$1.call(AbstractShiroFilter.java:365) ~[shiro-web-1.5.0.jar:1.5.0]
	at org.apache.shiro.subject.support.SubjectCallable.doCall(SubjectCallable.java:90) ~[shiro-core-1.5.0.jar:1.5.0]
	at org.apache.shiro.subject.support.SubjectCallable.call(SubjectCallable.java:83) ~[shiro-core-1.5.0.jar:1.5.0]
	at org.apache.shiro.subject.support.DelegatingSubject.execute(DelegatingSubject.java:387) ~[shiro-core-1.5.0.jar:1.5.0]
	at org.apache.shiro.web.servlet.AbstractShiroFilter.doFilterInternal(AbstractShiroFilter.java:362) ~[shiro-web-1.5.0.jar:1.5.0]

The value of pathPattern is changed from "/" to "" , matching path definition / = user failed.
Because chainName is "/", not "".

````
this pr's solution is bypass substring  when the request uri and pathPattern is /
please let me konw if any other better solution,
thanks  @jaynlau ^~^