### PR TITLE
[SHIRO-751] SimplePrincipalMap and SimplePrincipalCollection throw different exceptions for the same problem

### DIFF
--- a/core/src/main/java/org/apache/shiro/subject/SimplePrincipalCollection.java
+++ b/core/src/main/java/org/apache/shiro/subject/SimplePrincipalCollection.java
@@ -98,10 +98,10 @@ public class SimplePrincipalCollection implements MutablePrincipalCollection {
 
     public void add(Object principal, String realmName) {
         if (realmName == null) {
-            throw new IllegalArgumentException("realmName argument cannot be null.");
+            throw new NullPointerException("realmName argument cannot be null.");
         }
         if (principal == null) {
-            throw new IllegalArgumentException("principal argument cannot be null.");
+            throw new NullPointerException("principal argument cannot be null.");
         }
         this.cachedToString = null;
         getPrincipalsLazy(realmName).add(principal);
@@ -109,10 +109,10 @@ public class SimplePrincipalCollection implements MutablePrincipalCollection {
 
     public void addAll(Collection principals, String realmName) {
         if (realmName == null) {
-            throw new IllegalArgumentException("realmName argument cannot be null.");
+            throw new NullPointerException("realmName argument cannot be null.");
         }
         if (principals == null) {
-            throw new IllegalArgumentException("principals argument cannot be null.");
+            throw new NullPointerException("principals argument cannot be null.");
         }
         if (principals.isEmpty()) {
             throw new IllegalArgumentException("principals argument cannot be an empty collection.");


### PR DESCRIPTION
The bug report is https://issues.apache.org/jira/browse/SHIRO-751?page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel&focusedCommentId=17069374#comment-17069374

As suggested by Benjamin Marwell, I change the thrown exceptions of SimplePrincipalCollection#add and SimplePrincipalCollection#allAll