### PR TITLE
[SHIRO-530] INI parser does not properly handled backslashes at end o…

### DIFF
--- a/config/core/src/main/java/org/apache/shiro/config/Ini.java
+++ b/config/core/src/main/java/org/apache/shiro/config/Ini.java
@@ -68,14 +68,14 @@ public class Ini implements Map<String, Ini.Section> {
      * However, the xml configuration does allow backslashes in keys.</p>
      *
      * <p>The second separator group is the separator char (any of {@code :}, {@code =} or {@code \s})
-     * which must not be preceeded by an escaping slash.<br>
+     * which must not be preceeded by an escaping slash, but can be preceeded or followed by whitespace characters.<br>
      * The group {@code (?<!…)} is a negative lookback.<br></p>
      *
      * <p>The third capture group is everything else and hence the value.</p>
      */
     private static final Pattern SPLIT_KEY_VALUE =
             Pattern.compile(
-                    "^([a-z0-9\\\\.]*?)\\s?((?<!\\\\)[:\\s=])+\\s?(.*)$",
+                    "^([a-z0-9\\\\.-]*?)\\s*?((?<!\\\\)[:\\s=])+\\s*?(.*)$",
                     Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
 
     private final Map<String, Section> sections;

--- a/config/core/src/test/groovy/org/apache/shiro/config/IniTest.groovy
+++ b/config/core/src/test/groovy/org/apache/shiro/config/IniTest.groovy
@@ -142,27 +142,29 @@ public class IniTest {
         assertEquals("Truth", kv[0]);
         assertEquals("Beauty", kv[1]);
 
-        // Tests if any escapes are removed.
-        // SHIRO-530: This is unexpected, remove this.
+        // SHIRO-530: Keep backslashes in value.
         test = "Truth=Beau\\ty";
         kv = Ini.Section.splitKeyValue(test);
         assertEquals("Truth", kv[0]);
-        assertEquals("Beauty", kv[1]);
+        assertEquals("Beau\\ty", kv[1]);
 
-        // Tests if any escapes at the end are removed and read as a continuation char.
-        // If there is no next line, just remove them.
-        // SHIRO-530: This is unexpected, remove this.
+        // SHIRO-530: Keep backslashes in value.
         test = "Truth=Beauty\\";
         kv = Ini.Section.splitKeyValue(test);
         assertEquals("Truth", kv[0]);
-        assertEquals("Beauty", kv[1]);
+        assertEquals("Beauty\\", kv[1]);
+
+        // SHIRO-530: Keep backslashes in value.
+        test = "Truth= \\ Beauty\\";
+        kv = Ini.Section.splitKeyValue(test);
+        assertEquals("Truth", kv[0]);
+        assertEquals("\\ Beauty\\", kv[1]);
     }
 
     /**
-     * Tests if an escaped separator char will still be used as a separator char.
-     * SHIRO-530: This is unexpected, remove this.
+     * Tests if an escaped separator char will not be recognized as such.
      */
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testSplitKeyValueEscapedEquals()  {
         String test = "Truth\\=Beauty";
         String[] kv = Ini.Section.splitKeyValue(test);

--- a/config/core/src/test/groovy/org/apache/shiro/config/IniTest.groovy
+++ b/config/core/src/test/groovy/org/apache/shiro/config/IniTest.groovy
@@ -73,6 +73,22 @@ public class IniTest {
     }
 
     @Test
+    public void testBackslash() {
+        String test = "Truth=Beauty\\\\";
+        Ini ini = new Ini();
+        ini.load(test);
+
+        assertNotNull(ini.getSections());
+        assertEquals(1, ini.getSections().size());
+
+        Ini.Section section = ini.getSections().iterator().next();
+        assertEquals(Ini.DEFAULT_SECTION_NAME, section.getName());
+        assertFalse(section.isEmpty());
+        assertEquals(1, section.size());
+        assertEquals("Beauty\\\\", section.get("Truth"));
+    }
+
+    @Test
     public void testSplitKeyValue() {
         String test = "Truth Beauty";
         String[] kv = Ini.Section.splitKeyValue(test);
@@ -119,23 +135,37 @@ public class IniTest {
         assertEquals("Truth", kv[0]);
         assertEquals("Beauty", kv[1]);
 
+        // Escape characters are to be removed from the key.
+        // This is different behaviour compared to the XML config.
         test = "Tru\\th=Beauty";
         kv = Ini.Section.splitKeyValue(test);
         assertEquals("Truth", kv[0]);
         assertEquals("Beauty", kv[1]);
 
-        test = "Truth\\=Beauty";
-        kv = Ini.Section.splitKeyValue(test);
-        assertEquals("Truth", kv[0]);
-        assertEquals("Beauty", kv[1]);
-
+        // Tests if any escapes are removed.
+        // SHIRO-530: This is unexpected, remove this.
         test = "Truth=Beau\\ty";
         kv = Ini.Section.splitKeyValue(test);
         assertEquals("Truth", kv[0]);
         assertEquals("Beauty", kv[1]);
 
+        // Tests if any escapes at the end are removed and read as a continuation char.
+        // If there is no next line, just remove them.
+        // SHIRO-530: This is unexpected, remove this.
         test = "Truth=Beauty\\";
         kv = Ini.Section.splitKeyValue(test);
+        assertEquals("Truth", kv[0]);
+        assertEquals("Beauty", kv[1]);
+    }
+
+    /**
+     * Tests if an escaped separator char will still be used as a separator char.
+     * SHIRO-530: This is unexpected, remove this.
+     */
+    @Test
+    public void testSplitKeyValueEscapedEquals()  {
+        String test = "Truth\\=Beauty";
+        String[] kv = Ini.Section.splitKeyValue(test);
         assertEquals("Truth", kv[0]);
         assertEquals("Beauty", kv[1]);
     }


### PR DESCRIPTION
…f values

 - Replace key-value-splitting with regex
 - obscure disappearing escaping chars - please discuss!

Signed-off-by: Benjamin Marwell <bmarwell@gmail.com>

Now. If we would not want to break the existing (imho: obscure) way that shiro parses the `shiro.ini` file, we could introduce a parser strategy pattern.

But as the existing behaviour was not documented (other than tests), I would like to see a discussion about this.

Tests broken on purpose! See here why:  [SHIRO-530](https://issues.apache.org/jira/browse/SHIRO-530)