### PR TITLE
[SHIRO-530] INI parser does not properly handled backslashes at end o…

### DIFF
--- a/config/core/src/main/java/org/apache/shiro/config/Ini.java
+++ b/config/core/src/main/java/org/apache/shiro/config/Ini.java
@@ -587,7 +587,7 @@ public class Ini implements Map<String, Ini.Section> {
                 } else {
                     if (valueBuffer.length() == 0 && isKeyValueSeparatorChar(c) && !isCharEscaped(line, i)) {
                         //swallow the separator chars before we start building the value
-                    } else if (!isCharEscaped(line, i)){
+                    } else {
                         valueBuffer.append(c);
                     }
                 }

--- a/config/core/src/test/groovy/org/apache/shiro/config/IniTest.groovy
+++ b/config/core/src/test/groovy/org/apache/shiro/config/IniTest.groovy
@@ -73,6 +73,22 @@ public class IniTest {
     }
 
     @Test
+    public void testBackslash() {
+        String test = "Truth=Beauty\\\\";
+        Ini ini = new Ini();
+        ini.load(test);
+
+        assertNotNull(ini.getSections());
+        assertEquals(1, ini.getSections().size());
+
+        Ini.Section section = ini.getSections().iterator().next();
+        assertEquals(Ini.DEFAULT_SECTION_NAME, section.getName());
+        assertFalse(section.isEmpty());
+        assertEquals(1, section.size());
+        assertEquals("Beauty\\\\", section.get("Truth"));
+    }
+
+    @Test
     public void testSplitKeyValue() {
         String test = "Truth Beauty";
         String[] kv = Ini.Section.splitKeyValue(test);
@@ -119,23 +135,39 @@ public class IniTest {
         assertEquals("Truth", kv[0]);
         assertEquals("Beauty", kv[1]);
 
+        // Escape characters are to be removed from the key.
+        // This is different behaviour compared to the XML config.
         test = "Tru\\th=Beauty";
         kv = Ini.Section.splitKeyValue(test);
         assertEquals("Truth", kv[0]);
         assertEquals("Beauty", kv[1]);
 
-        test = "Truth\\=Beauty";
-        kv = Ini.Section.splitKeyValue(test);
-        assertEquals("Truth", kv[0]);
-        assertEquals("Beauty", kv[1]);
-
+        // SHIRO-530: Keep backslashes in value.
         test = "Truth=Beau\\ty";
         kv = Ini.Section.splitKeyValue(test);
         assertEquals("Truth", kv[0]);
-        assertEquals("Beauty", kv[1]);
+        assertEquals("Beau\\ty", kv[1]);
 
+        // SHIRO-530: Keep backslashes in value.
         test = "Truth=Beauty\\";
         kv = Ini.Section.splitKeyValue(test);
+        assertEquals("Truth", kv[0]);
+        assertEquals("Beauty\\", kv[1]);
+
+        // SHIRO-530: Keep backslashes in value.
+        test = "Truth= \\ Beauty\\";
+        kv = Ini.Section.splitKeyValue(test);
+        assertEquals("Truth", kv[0]);
+        assertEquals("\\ Beauty\\", kv[1]);
+    }
+
+    /**
+     * Tests if an escaped separator char will not be recognized as such.
+     */
+    @Test
+    public void testSplitKeyValueEscapedEquals()  {
+        String test = "Truth\\=Beauty";
+        String[] kv = Ini.Section.splitKeyValue(test);
         assertEquals("Truth", kv[0]);
         assertEquals("Beauty", kv[1]);
     }


### PR DESCRIPTION
…f values

 - Do not skip escape characters for the value (new behaviour demanded by SHIRO-530).
 - rearrange and comment tests to reflect old and new, desired behaviour.

Signed-off-by: Benjamin Marwell <bmarwell@gmail.com>

Alternative to https://github.com/apache/shiro/pull/209