### PR TITLE
[SHIRO-762] Mark `SecurityUtils.securityManager` as volatile

### DIFF
--- a/core/src/main/java/org/apache/shiro/SecurityUtils.java
+++ b/core/src/main/java/org/apache/shiro/SecurityUtils.java
@@ -34,7 +34,7 @@ public abstract class SecurityUtils {
      * ONLY used as a 'backup' in VM Singleton environments (that is, standalone environments), since the
      * ThreadContext should always be the primary source for Subject instances when possible.
      */
-    private static SecurityManager securityManager;
+    private static volatile SecurityManager securityManager;
 
     /**
      * Returns the currently accessible {@code Subject} available to the calling code depending on


### PR DESCRIPTION
As it can be modified and read by different threads. This has been biting me for a very long time now.