### PR TITLE
[SHIRO-750] update jax-rs dependency to jakarta.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <spring.version>5.2.5.RELEASE</spring.version>
         <spring-boot.version>2.2.6.RELEASE</spring-boot.version>
         <guice.version>4.2.2</guice.version>
-        <jaxrs.api.version>2.0.1</jaxrs.api.version>
+        <jaxrs.api.version>2.1.6</jaxrs.api.version>
         <htmlunit.version>2.39.0</htmlunit.version>
 
         <!-- Test 3rd-party dependencies: -->

--- a/samples/jaxrs/pom.xml
+++ b/samples/jaxrs/pom.xml
@@ -77,6 +77,13 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>${jaxrs.api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <!-- Required for any libraries that expect to call the commons logging APIs -->
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>

--- a/support/jaxrs/pom.xml
+++ b/support/jaxrs/pom.xml
@@ -45,9 +45,10 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <version>${jaxrs.api.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Test Deps -->


### PR DESCRIPTION
  - Non-Breaking change.
  - Also set the scope to provided. Containers will provide this API.
  - Also add the dependency to the samples, so they do not use a
  transitive dependency.