### PR TITLE
[SHIRO-772] Remove PowerMock from EnvironmentLoaderServiceTest.java.

### DIFF
--- a/web/src/main/java/org/apache/shiro/web/env/EnvironmentLoader.java
+++ b/web/src/main/java/org/apache/shiro/web/env/EnvironmentLoader.java
@@ -202,8 +202,7 @@ public class EnvironmentLoader {
 
         WebEnvironment webEnvironment = null;
         // try to load WebEnvironment as a service
-        ServiceLoader<WebEnvironment> serviceLoader = ServiceLoader.load(WebEnvironment.class);
-        Iterator<WebEnvironment> iterator = serviceLoader.iterator();
+        Iterator<WebEnvironment> iterator = doLoadWebEnvironmentsFromServiceLoader();
 
         // Use the first one
         if (iterator.hasNext()) {
@@ -221,6 +220,12 @@ public class EnvironmentLoader {
                     "servlet init parameter '"+ ENVIRONMENT_CLASS_PARAM +"'. Found: " + allWebEnvironments);
         }
         return webEnvironment;
+    }
+
+    protected Iterator<WebEnvironment> doLoadWebEnvironmentsFromServiceLoader() {
+        ServiceLoader<WebEnvironment> serviceLoader = ServiceLoader.load(WebEnvironment.class);
+
+        return serviceLoader.iterator();
     }
 
     /**

--- a/web/src/test/java/org/apache/shiro/web/env/EnvironmentLoaderServiceTest.java
+++ b/web/src/test/java/org/apache/shiro/web/env/EnvironmentLoaderServiceTest.java
@@ -22,15 +22,10 @@ import org.apache.shiro.config.ConfigurationException;
 import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import javax.servlet.ServletContext;
 import java.util.Arrays;
 import java.util.List;
-import java.util.ServiceLoader;
 
 import static org.easymock.EasyMock.expect;
 import static org.hamcrest.Matchers.*;
@@ -39,36 +34,25 @@ import static org.hamcrest.MatcherAssert.*;
 /**
  * Tests for {@link EnvironmentLoader} that depend on PowerMock the stub out a ServiceLoader.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(EnvironmentLoader.class)
 public class EnvironmentLoaderServiceTest {
 
     @Test()
     public void singleServiceTest() throws Exception {
 
-        List<WebEnvironmentStub> environmentList = Arrays.asList(new WebEnvironmentStub());
-
         ServletContext servletContext = EasyMock.mock(ServletContext.class);
         expect(servletContext.getInitParameter("shiroEnvironmentClass")).andReturn(null);
         expect(servletContext.getInitParameter("shiroConfigLocations")).andReturn(null);
-
-        PowerMock.mockStaticPartialStrict(ServiceLoader.class, "load");
-
-        final ServiceLoader serviceLoader = PowerMock.createMock(ServiceLoader.class);
-
-        EasyMock.expect(ServiceLoader.load(WebEnvironment.class)).andReturn(serviceLoader);
-        EasyMock.expect(serviceLoader.iterator()).andReturn(environmentList.iterator());
+        expect(servletContext.getResourceAsStream("/WEB-INF/shiro.ini")).andReturn(
+                getClass().getResourceAsStream("/EmptyShiroIni.ini"));
 
         EasyMock.replay(servletContext);
-        PowerMock.replayAll();
 
         WebEnvironment resultEnvironment = new EnvironmentLoader().createEnvironment(servletContext);
 
-        PowerMock.verifyAll();
         EasyMock.verify(servletContext);
 
-        assertThat(resultEnvironment, instanceOf(WebEnvironmentStub.class));
-        WebEnvironmentStub environmentStub = (WebEnvironmentStub) resultEnvironment;
+        assertThat(resultEnvironment, instanceOf(IniWebEnvironment.class));
+        IniWebEnvironment environmentStub = (IniWebEnvironment) resultEnvironment;
 
         assertThat(environmentStub.getServletContext(), sameInstance(servletContext));
     }
@@ -76,48 +60,42 @@ public class EnvironmentLoaderServiceTest {
     @Test()
     public void multipleServiceTest() throws Exception {
 
-        List<WebEnvironmentStub> environmentList = Arrays.asList(new WebEnvironmentStub(), new WebEnvironmentStub());
+        List<WebEnvironment> environmentList = Arrays.asList(new WebEnvironmentStub(), new WebEnvironmentStub());
 
         ServletContext servletContext = EasyMock.mock(ServletContext.class);
-        expect(servletContext.getInitParameter("shiroEnvironmentClass")).andReturn(null);
-
-        PowerMock.mockStaticPartialStrict(ServiceLoader.class, "load");
-
-        final ServiceLoader serviceLoader = PowerMock.createMock(ServiceLoader.class);
-
-        EasyMock.expect(ServiceLoader.load(WebEnvironment.class)).andReturn(serviceLoader);
-        EasyMock.expect(serviceLoader.iterator()).andReturn(environmentList.iterator());
+        expect(servletContext.getInitParameter(EnvironmentLoader.ENVIRONMENT_CLASS_PARAM)).andReturn(null);
 
         EasyMock.replay(servletContext);
-        PowerMock.replayAll();
+
+        final EnvironmentLoader environmentLoader = EasyMock.createMockBuilder(EnvironmentLoader.class)
+                .addMockedMethod("doLoadWebEnvironmentsFromServiceLoader")
+                .createMock();
+        EasyMock.expect(environmentLoader.doLoadWebEnvironmentsFromServiceLoader()).andReturn(environmentList.iterator());
+        EasyMock.replay(environmentLoader);
 
         try {
-            new EnvironmentLoader().createEnvironment(servletContext);
+            environmentLoader.createEnvironment(servletContext);
             Assert.fail("Expected ConfigurationException to be thrown");
         }
         catch (ConfigurationException e) {
             assertThat(e.getMessage(), stringContainsInOrder("zero or exactly one", "shiroEnvironmentClass"));
         }
 
-        PowerMock.verifyAll();
         EasyMock.verify(servletContext);
+        EasyMock.verify(environmentLoader);
     }
 
     @Test()
     public void loadFromInitParamTest() throws Exception {
 
         ServletContext servletContext = EasyMock.mock(ServletContext.class);
-        expect(servletContext.getInitParameter("shiroEnvironmentClass")).andReturn(WebEnvironmentStub.class.getName());
+        expect(servletContext.getInitParameter(EnvironmentLoader.ENVIRONMENT_CLASS_PARAM)).andReturn(WebEnvironmentStub.class.getName());
         expect(servletContext.getInitParameter("shiroConfigLocations")).andReturn(null);
 
-        PowerMock.mockStaticPartialStrict(ServiceLoader.class, "load");
-
         EasyMock.replay(servletContext);
-        PowerMock.replayAll();
 
         WebEnvironment resultEnvironment = new EnvironmentLoader().createEnvironment(servletContext);
 
-        PowerMock.verifyAll();
         EasyMock.verify(servletContext);
 
         assertThat(resultEnvironment, instanceOf(WebEnvironmentStub.class));

--- a/web/src/test/resources/EmptyShiroIni.ini
+++ b/web/src/test/resources/EmptyShiroIni.ini
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+[main]
+
+[urls]
+/* = anon


### PR DESCRIPTION
  - Enables building with JDK11 and 14
  - refactored ServiceLoader loading into separate method to enable mocking.