### PR TITLE
[SHIRO-773] update groovy for JDK14 builds.

### DIFF
--- a/crypto/cipher/src/main/java/org/apache/shiro/crypto/AesCipherService.java
+++ b/crypto/cipher/src/main/java/org/apache/shiro/crypto/AesCipherService.java
@@ -95,6 +95,7 @@ public class AesCipherService extends DefaultBlockCipherService {
         setMode(OperationMode.GCM);
         setStreamingMode(OperationMode.GCM);
         setPaddingScheme(PaddingScheme.NONE);
+        setStreamingPaddingScheme(PaddingScheme.NONE);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <!-- Test 3rd-party dependencies: -->
         <easymock.version>4.0.2</easymock.version>
         <gmaven.version>1.8.0</gmaven.version>
-        <groovy.version>2.5.8</groovy.version>
+        <groovy.version>3.0.3</groovy.version>
         <junit.version>4.12</junit.version>
         <junit.server.jetty.version>0.11.0</junit.server.jetty.version>
         <hibernate.version>5.4.3.Final</hibernate.version>


### PR DESCRIPTION
 - Updated groovy to 3.x. 2.5.10 would have been enough, but here were no failing tests due to the use of the new major version, so why not just update?
 - Added an oversight from [SHIRO-736](https://issues.apache.org/jira/browse/SHIRO-736) where it was found out that the GCM padding cipher is just an alias for the non-padding one. It was only added for block mode ciphers. This is needed to get Shiro compiling with JDK14.