### PR TITLE
[SHIRO-780] NOTICE files of shiro components don't match NOTICE in so…

### DIFF
--- a/cache/src/main/resources/META-INF/NOTICE
+++ b/cache/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/config/core/src/main/resources/META-INF/NOTICE
+++ b/config/core/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/config/ogdl/src/main/resources/META-INF/NOTICE
+++ b/config/ogdl/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/core/src/main/resources/META-INF/NOTICE
+++ b/core/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/crypto/cipher/src/main/resources/META-INF/NOTICE
+++ b/crypto/cipher/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/crypto/core/src/main/resources/META-INF/NOTICE
+++ b/crypto/core/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/crypto/hash/src/main/resources/META-INF/NOTICE
+++ b/crypto/hash/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/event/src/main/resources/META-INF/NOTICE
+++ b/event/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/lang/src/main/resources/META-INF/NOTICE
+++ b/lang/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/samples/aspectj/src/main/resources/META-INF/NOTICE
+++ b/samples/aspectj/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/samples/guice/src/main/resources/META-INF/NOTICE
+++ b/samples/guice/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/samples/jaxrs/src/main/resources/META-INF/NOTICE
+++ b/samples/jaxrs/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/samples/quickstart-guice/src/main/resources/META-INF/NOTICE
+++ b/samples/quickstart-guice/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/samples/quickstart/src/main/resources/META-INF/NOTICE
+++ b/samples/quickstart/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/samples/servlet-plugin/src/main/resources/META-INF/NOTICE
+++ b/samples/servlet-plugin/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/samples/spring-boot-web/src/main/resources/META-INF/NOTICE
+++ b/samples/spring-boot-web/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/samples/spring-boot/src/main/resources/META-INF/NOTICE
+++ b/samples/spring-boot/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/samples/spring-hibernate/src/main/resources/META-INF/NOTICE
+++ b/samples/spring-hibernate/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/samples/spring-mvc/src/main/resources/META-INF/NOTICE
+++ b/samples/spring-mvc/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/samples/spring/src/main/resources/META-INF/NOTICE
+++ b/samples/spring/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/samples/web/src/main/resources/META-INF/NOTICE
+++ b/samples/web/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/support/aspectj/src/main/resources/META-INF/NOTICE
+++ b/support/aspectj/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/support/ehcache/src/main/resources/META-INF/NOTICE
+++ b/support/ehcache/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/support/guice/src/main/resources/META-INF/NOTICE
+++ b/support/guice/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/support/hazelcast/src/main/resources/META-INF/NOTICE
+++ b/support/hazelcast/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/support/jaxrs/src/main/resources/META-INF/NOTICE
+++ b/support/jaxrs/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/support/quartz/src/main/resources/META-INF/NOTICE
+++ b/support/quartz/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/support/spring-boot/spring-boot-starter/src/main/resources/META-INF/NOTICE
+++ b/support/spring-boot/spring-boot-starter/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/support/spring-boot/spring-boot-web-starter/src/main/resources/META-INF/NOTICE
+++ b/support/spring-boot/spring-boot-web-starter/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/support/spring/src/main/resources/META-INF/NOTICE
+++ b/support/spring/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/tools/hasher/src/main/resources/META-INF/NOTICE
+++ b/tools/hasher/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).

--- a/web/src/main/resources/META-INF/NOTICE
+++ b/web/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache Shiro
+Copyright 2008-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The implementation for org.apache.shiro.util.SoftHashMap is based 
+on initial ideas from Dr. Heinz Kabutz's publicly posted version 
+available at http://www.javaspecialists.eu/archive/Issue015.html,
+with continued modifications.  
+
+Certain parts (StringUtils, IpAddressMatcher, etc.) of the source
+code for this  product was copied for simplicity and to reduce
+dependencies  from the source code developed by the Spring Framework
+Project  (http://www.springframework.org).


### PR DESCRIPTION
…urce code repository

The apache-jar-resource-bundle generate default NOTICE file from velocity template, so we have to override this default NOTICE file by the root project one.