### PR TITLE
[SHIRO-784] Fixed issue where no custom filters are defined in spring (non-boot) apps

### DIFF
--- a/support/spring/src/main/java/org/apache/shiro/spring/web/config/AbstractShiroWebFilterConfiguration.java
+++ b/support/spring/src/main/java/org/apache/shiro/spring/web/config/AbstractShiroWebFilterConfiguration.java
@@ -38,7 +38,7 @@ public class AbstractShiroWebFilterConfiguration {
     @Autowired
     protected ShiroFilterChainDefinition shiroFilterChainDefinition;
 
-    @Autowired
+    @Autowired(required = false)
     protected Map<String, Filter> filterMap;
 
     @Value("#{ @environment['shiro.loginUrl'] ?: '/login.jsp' }")
@@ -59,7 +59,10 @@ public class AbstractShiroWebFilterConfiguration {
 
         filterFactoryBean.setSecurityManager(securityManager);
         filterFactoryBean.setFilterChainDefinitionMap(shiroFilterChainDefinition.getFilterChainMap());
-        filterFactoryBean.setFilters(filterMap);
+
+        if (filterMap != null) {
+            filterFactoryBean.setFilters(filterMap);
+        }
 
         return filterFactoryBean;
     }

--- a/support/spring/src/test/groovy/org/apache/shiro/spring/config/ShiroWebConfigurationTest.groovy
+++ b/support/spring/src/test/groovy/org/apache/shiro/spring/config/ShiroWebConfigurationTest.groovy
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.spring.config
+
+import org.apache.shiro.authc.UsernamePasswordToken
+import org.apache.shiro.authz.ModularRealmAuthorizer
+import org.apache.shiro.event.EventBus
+import org.apache.shiro.mgt.DefaultSecurityManager
+import org.apache.shiro.mgt.SecurityManager
+import org.apache.shiro.realm.text.TextConfigurationRealm
+import org.apache.shiro.spring.testconfig.RealmTestConfiguration
+import org.apache.shiro.spring.web.ShiroFilterFactoryBean
+import org.apache.shiro.spring.web.config.ShiroWebConfiguration
+import org.apache.shiro.spring.web.config.ShiroWebFilterConfiguration
+import org.apache.shiro.subject.Subject
+import org.junit.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests
+
+import static org.hamcrest.Matchers.*
+import static org.junit.Assert.*
+
+/**
+ * @since 1.4.0
+ */
+@ContextConfiguration(classes = [RealmTestConfiguration, ShiroConfiguration, ShiroWebConfiguration, ShiroWebFilterConfiguration])
+public class ShiroWebConfigurationTest extends AbstractJUnit4SpringContextTests {
+
+    @Autowired
+    private SecurityManager securityManager
+
+    @Autowired
+    private EventBus eventBus;
+
+    @Autowired
+    private ShiroFilterFactoryBean shiroFilterFactoryBean
+
+    @Test
+    public void testMinimalConfiguration() {
+
+        // first do a quick check of the injected objects
+        assertNotNull securityManager
+        assertThat securityManager.realms, allOf(hasSize(1), hasItem(instanceOf(TextConfigurationRealm)))
+        assertNull securityManager.cacheManager
+
+        assertNotNull shiroFilterFactoryBean
+        assertThat shiroFilterFactoryBean.filters, anEmptyMap()
+
+        assertSame(((DefaultSecurityManager)securityManager).getEventBus(), eventBus)
+
+        def defaultSecurityManager = (DefaultSecurityManager) securityManager
+        def authorizor = (ModularRealmAuthorizer) defaultSecurityManager.getAuthorizer();
+        assertNull authorizor.rolePermissionResolver
+        assertNull authorizor.permissionResolver
+
+        // now lets do a couple quick permission tests to make sure everything has been initialized correctly.
+        Subject joeCoder = new Subject.Builder(securityManager).buildSubject()
+        joeCoder.login(new UsernamePasswordToken("joe.coder", "password"))
+        joeCoder.checkPermission("read")
+        assertTrue joeCoder.hasRole("user")
+        assertFalse joeCoder.hasRole("admin")
+        joeCoder.logout()
+    }
+
+}


### PR DESCRIPTION
filterMap should be not required, as this could be empty