### PR TITLE
[SHIRO-398] - Renamed the variable interval to sessionValidationInterval

### DIFF
--- a/core/src/main/java/org/apache/shiro/session/mgt/AbstractValidatingSessionManager.java
+++ b/core/src/main/java/org/apache/shiro/session/mgt/AbstractValidatingSessionManager.java
@@ -213,7 +213,7 @@ public abstract class AbstractValidatingSessionManager extends AbstractNativeSes
             log.debug("No sessionValidationScheduler set.  Attempting to create default instance.");
         }
         scheduler = new ExecutorServiceSessionValidationScheduler(this);
-        scheduler.setInterval(getSessionValidationInterval());
+        scheduler.setSessionValidationInterval(getSessionValidationInterval());
         if (log.isTraceEnabled()) {
             log.trace("Created default SessionValidationScheduler instance of type [" + scheduler.getClass().getName() + "].");
         }

--- a/core/src/main/java/org/apache/shiro/session/mgt/ExecutorServiceSessionValidationScheduler.java
+++ b/core/src/main/java/org/apache/shiro/session/mgt/ExecutorServiceSessionValidationScheduler.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 /**
  * SessionValidationScheduler implementation that uses a
  * {@link ScheduledExecutorService} to call {@link ValidatingSessionManager#validateSessions()} every
- * <em>{@link #getInterval interval}</em> milliseconds.
+ * <em>{@link #getSessionValidationInterval sessionValidationInterval}</em> milliseconds.
  *
  * @since 0.9
  */
@@ -44,7 +44,7 @@ public class ExecutorServiceSessionValidationScheduler implements SessionValidat
 
     ValidatingSessionManager sessionManager;
     private ScheduledExecutorService service;
-    private long interval = DefaultSessionManager.DEFAULT_SESSION_VALIDATION_INTERVAL;
+    private long sessionValidationInterval = DefaultSessionManager.DEFAULT_SESSION_VALIDATION_INTERVAL;
     private boolean enabled = false;
     private String threadNamePrefix = "SessionValidationThread-";
 
@@ -64,12 +64,12 @@ public class ExecutorServiceSessionValidationScheduler implements SessionValidat
         this.sessionManager = sessionManager;
     }
 
-    public long getInterval() {
-        return interval;
+    public long getSessionValidationInterval() {
+        return sessionValidationInterval;
     }
 
-    public void setInterval(long interval) {
-        this.interval = interval;
+    public void setSessionValidationInterval(long sessionValidationInterval) {
+        this.sessionValidationInterval = sessionValidationInterval;
     }
 
     public boolean isEnabled() {
@@ -91,7 +91,7 @@ public class ExecutorServiceSessionValidationScheduler implements SessionValidat
     //TODO Implement an integration test to test for jvm exit as part of the standalone example
     // (so we don't have to change the unit test execution model for the core module)
     public void enableSessionValidation() {
-        if (this.interval > 0l) {
+        if (this.sessionValidationInterval > 0l) {
             this.service = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {  
 	            private final AtomicInteger count = new AtomicInteger(1);
 
@@ -102,7 +102,8 @@ public class ExecutorServiceSessionValidationScheduler implements SessionValidat
 	                return thread;  
 	            }  
             });                  
-            this.service.scheduleAtFixedRate(this, interval, interval, TimeUnit.MILLISECONDS);
+            this.service.scheduleAtFixedRate(this, sessionValidationInterval,
+                sessionValidationInterval, TimeUnit.MILLISECONDS);
         }
         this.enabled = true;
     }

--- a/core/src/test/java/org/apache/shiro/session/mgt/ExecutorServiceSessionValidationSchedulerTest.java
+++ b/core/src/test/java/org/apache/shiro/session/mgt/ExecutorServiceSessionValidationSchedulerTest.java
@@ -36,7 +36,7 @@ public class ExecutorServiceSessionValidationSchedulerTest {
         executorServiceSessionValidationScheduler = new ExecutorServiceSessionValidationScheduler();
         executorServiceSessionValidationScheduler.setSessionManager(defaultSessionManager);
         executorServiceSessionValidationScheduler.setThreadNamePrefix("test-");
-        executorServiceSessionValidationScheduler.setInterval(1000L);
+        executorServiceSessionValidationScheduler.setSessionValidationInterval(1000L);
         executorServiceSessionValidationScheduler.enableSessionValidation();
     }
 
@@ -81,7 +81,7 @@ public class ExecutorServiceSessionValidationSchedulerTest {
         executorServiceSessionValidationScheduler = new ExecutorServiceSessionValidationScheduler();
         executorServiceSessionValidationScheduler.setSessionManager(defaultSessionManager);
         executorServiceSessionValidationScheduler.setThreadNamePrefix("test-");
-        executorServiceSessionValidationScheduler.setInterval(1000L);
+        executorServiceSessionValidationScheduler.setSessionValidationInterval(1000L);
         executorServiceSessionValidationScheduler.enableSessionValidation();
         defaultSessionManager.create(session);
         Thread.sleep(2000L);


### PR DESCRIPTION
Closes SHIRO-398.

Refactored the variable name to be consistent across implementations.

