### PR TITLE
[No JIRA] Fix inefficient iterators

### DIFF
--- a/core/src/main/java/org/apache/shiro/realm/text/TextConfigurationRealm.java
+++ b/core/src/main/java/org/apache/shiro/realm/text/TextConfigurationRealm.java
@@ -148,8 +148,9 @@ public class TextConfigurationRealm extends SimpleAccountRealm {
         if (roleDefs == null || roleDefs.isEmpty()) {
             return;
         }
-        for (String rolename : roleDefs.keySet()) {
-            String value = roleDefs.get(rolename);
+        for (Map.Entry<String,String> entry : roleDefs.entrySet()) {
+            String rolename = entry.getKey();
+            String value = entry.getValue();
 
             SimpleRole role = getRole(rolename);
             if (role == null) {
@@ -177,9 +178,9 @@ public class TextConfigurationRealm extends SimpleAccountRealm {
         if (userDefs == null || userDefs.isEmpty()) {
             return;
         }
-        for (String username : userDefs.keySet()) {
-
-            String value = userDefs.get(username);
+        for (Map.Entry<String,String> entry : userDefs.entrySet()) {
+            String username = entry.getKey();
+            String value = entry.getValue();
 
             String[] passwordAndRolesArray = StringUtils.split(value);
 


### PR DESCRIPTION
Iterating over a map then looking up a key guarantees 2x the hash map lookups than what is necessary.  See [here](https://fbinfer.com/docs/next/all-issue-types#inefficient_keyset_iterator) for a more detailed writeup.

This instance was found [using the Muse analysis platform](https://console.muse.dev/result/ayorra/shiro/01EFG4TPKZ5KF3KARJ1HC79P3A?search=inefficient&tab=results) (which I work on), specifically with the Infer tool.  It appears Apache is pro-CI and the analysis worked out of the box and without configuration.  Perhaps we should [enable it](https://github.com/apps/muse-dev) to run on all pull requests, meaning new bugs would receive comments ([example](https://github.com/TomMD/shiro/pull/2)).

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

