### PR TITLE
[SHIRO-797] Shiro 1.7.0 is lower than using springboot version 2.0.7 dependency error

### DIFF
--- a/support/spring-boot/spring-boot-starter/src/test/groovy/org/apache/shiro/spring/boot/autoconfigure/SpringFactoriesTest.groovy
+++ b/support/spring-boot/spring-boot-starter/src/test/groovy/org/apache/shiro/spring/boot/autoconfigure/SpringFactoriesTest.groovy
@@ -1,0 +1,24 @@
+package org.apache.shiro.spring.boot.autoconfigure
+
+import org.junit.Test
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.matchesPattern
+import static org.hamcrest.Matchers.not
+
+class SpringFactoriesTest {
+
+    @Test
+    void springFactoriesConfigContainsNoWhitespace() {
+        Properties props = new Properties()
+        props.load(new FileReader("src/main/resources/META-INF/spring.factories"))
+        assertNoWhitespaceInEntries(props)
+    }
+
+    static private assertNoWhitespaceInEntries(Properties props) {
+        props.each{ key, val ->
+            assertThat "Property [${key}] contains whitespace",
+            props.get("org.springframework.boot.autoconfigure.EnableAutoConfiguration"), not(matchesPattern(".*\\s.*"))
+        }
+    }
+}

--- a/support/spring-boot/spring-boot-starter/src/test/groovy/org/apache/shiro/spring/boot/autoconfigure/SpringFactoriesTest.groovy
+++ b/support/spring-boot/spring-boot-starter/src/test/groovy/org/apache/shiro/spring/boot/autoconfigure/SpringFactoriesTest.groovy
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.shiro.spring.boot.autoconfigure
 
 import org.junit.Test

--- a/support/spring-boot/spring-boot-web-starter/src/main/resources/META-INF/spring.factories
+++ b/support/spring-boot/spring-boot-web-starter/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,4 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration = \
   org.apache.shiro.spring.config.web.autoconfigure.ShiroWebAutoConfiguration,\
-  org.apache.shiro.spring.config.web.autoconfigure.ShiroWebFilterConfiguration, \
+  org.apache.shiro.spring.config.web.autoconfigure.ShiroWebFilterConfiguration,\
   org.apache.shiro.spring.config.web.autoconfigure.ShiroWebMvcAutoConfiguration

--- a/support/spring-boot/spring-boot-web-starter/src/test/groovy/org/apache/shiro/spring/boot/autoconfigure/web/WebSpringFactoriesTest.groovy
+++ b/support/spring-boot/spring-boot-web-starter/src/test/groovy/org/apache/shiro/spring/boot/autoconfigure/web/WebSpringFactoriesTest.groovy
@@ -1,0 +1,24 @@
+package org.apache.shiro.spring.boot.autoconfigure.web
+
+import org.junit.Test
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.matchesPattern
+import static org.hamcrest.Matchers.not
+
+class WebSpringFactoriesTest {
+
+    @Test
+    void springFactoriesConfigContainsNoWhitespace() {
+        Properties props = new Properties()
+        props.load(new FileReader("src/main/resources/META-INF/spring.factories"))
+        assertNoWhitespaceInEntries(props)
+    }
+
+    static private assertNoWhitespaceInEntries(Properties props) {
+        props.each{ key, val ->
+            assertThat "Property [${key}] contains whitespace",
+            props.get("org.springframework.boot.autoconfigure.EnableAutoConfiguration"), not(matchesPattern(".*\\s.*"))
+        }
+    }
+}

--- a/support/spring-boot/spring-boot-web-starter/src/test/groovy/org/apache/shiro/spring/boot/autoconfigure/web/WebSpringFactoriesTest.groovy
+++ b/support/spring-boot/spring-boot-web-starter/src/test/groovy/org/apache/shiro/spring/boot/autoconfigure/web/WebSpringFactoriesTest.groovy
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.shiro.spring.boot.autoconfigure.web
 
 import org.junit.Test


### PR DESCRIPTION
hotfix Springboot in versions lower than 2.0.7 does not have trim classname, one more space causes an error

https://issues.apache.org/jira/projects/SHIRO/issues/SHIRO-797?filter=allopenissues