### PR TITLE
Fix: flushes ByteArrayOutputStream before using

### DIFF
--- a/lang/src/main/java/org/apache/shiro/lang/io/DefaultSerializer.java
+++ b/lang/src/main/java/org/apache/shiro/lang/io/DefaultSerializer.java
@@ -47,7 +47,7 @@ public class DefaultSerializer<T> implements Serializer<T> {
             ObjectOutputStream oos = new ObjectOutputStream(bos);
             oos.writeObject(o);
             oos.close();
-	    baos.flush();
+            baos.flush();
             return baos.toByteArray();
         } catch (IOException e) {
             String msg = "Unable to serialize object [" + o + "].  " +

--- a/lang/src/main/java/org/apache/shiro/lang/io/DefaultSerializer.java
+++ b/lang/src/main/java/org/apache/shiro/lang/io/DefaultSerializer.java
@@ -47,6 +47,7 @@ public class DefaultSerializer<T> implements Serializer<T> {
             ObjectOutputStream oos = new ObjectOutputStream(bos);
             oos.writeObject(o);
             oos.close();
+	    baos.flush();
             return baos.toByteArray();
         } catch (IOException e) {
             String msg = "Unable to serialize object [" + o + "].  " +


### PR DESCRIPTION
Hi, I would like to start by saying I am sorry for not following your community guidelines but since this patch is really tiny, I didn't think it would be necessary to create a task at Jira or follow the other procedures, if this is considered unnaceptable, do let me know and I will open this PR as specified. Thanks for the comprehension.

Flushes OutputStream before using the underlying ByteArrayOutputStream: when an OutputStream (or its subclass) instance is built on top of an underlying ByteArrayOutputStream instance, it should be flushed or closed before the underlying instance's toByteArray() is invoked. Failing to fulfill this requirement may cause toByteArray() to return incomplete contents.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

