### PR TITLE
[SHIRO-804] - Avoid conflicts with spring boot aop

### DIFF
--- a/support/spring-boot/spring-boot-starter/src/main/java/org/apache/shiro/spring/boot/autoconfigure/ShiroAnnotationProcessorAutoConfiguration.java
+++ b/support/spring-boot/spring-boot-starter/src/main/java/org/apache/shiro/spring/boot/autoconfigure/ShiroAnnotationProcessorAutoConfiguration.java
@@ -21,6 +21,7 @@ package org.apache.shiro.spring.boot.autoconfigure;
 import org.apache.shiro.mgt.SecurityManager;
 import org.apache.shiro.spring.config.AbstractShiroAnnotationProcessorConfiguration;
 import org.apache.shiro.spring.security.interceptor.AuthorizationAttributeSourceAdvisor;
+import org.springframework.aop.config.AopConfigUtils;
 import org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -38,7 +39,9 @@ public class ShiroAnnotationProcessorAutoConfiguration extends AbstractShiroAnno
 
     @Bean
     @DependsOn("lifecycleBeanPostProcessor")
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(
+            value = DefaultAdvisorAutoProxyCreator.class, name = AopConfigUtils.AUTO_PROXY_CREATOR_BEAN_NAME
+    )
     @Override
     public DefaultAdvisorAutoProxyCreator defaultAdvisorAutoProxyCreator() {
         return super.defaultAdvisorAutoProxyCreator();


### PR DESCRIPTION
If there is a spring-boot-starter-aop dependency in the project's classpath, Spring will automatically create a bean named "org.springframework.aop.config.internalAutoProxyCreator". 
This will cause Spring beans to be proxied twice. If one is a JDK dynamic proxy and the other is a CGLIB proxy, then the system will fail to start.
We may be able to avoid such errors by modifying the defaultAdvisorAutoProxyCreator method of the ShiroAnnotationProcessorAutoConfiguration class.
I have tested this modification in my own project and it works. Sorry, my English is not very good, this paragraph is written using Google Translate.

Spring boot log:
```html
ShiroAnnotationProcessorAutoConfiguration#defaultAdvisorAutoProxyCreator:
    Did not match:
        - @ConditionalOnMissingBean (names: org.springframework.aop.config.internalAutoProxyCreator; types: org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator; SearchStrategy: all) found beans named org.springframework.aop.config.internalAutoProxyCreator (OnBeanCondition)
```