### PR TITLE
[SHIRO-817] Update `CommonsInterpolator` doc to reflect actual behavior

### DIFF
--- a/config/ogdl/src/main/java/org/apache/shiro/config/ogdl/CommonsInterpolator.java
+++ b/config/ogdl/src/main/java/org/apache/shiro/config/ogdl/CommonsInterpolator.java
@@ -35,12 +35,12 @@ import org.apache.commons.configuration2.interpol.SystemPropertiesLookup;
  *     </tr>
  *     <tr>
  *         <td>sys</td>
- *         <td>${sys:os.name}</td>
+ *         <td>${os.name}</td>
  *         <td>mac os x</td>
  *     </tr>
  *     <tr>
  *         <td>env</td>
- *         <td>${env:EDITOR}</td>
+ *         <td>${EDITOR}</td>
  *         <td>vi</td>
  *     </tr>
  *     <tr>

--- a/config/ogdl/src/main/java/org/apache/shiro/config/ogdl/CommonsInterpolator.java
+++ b/config/ogdl/src/main/java/org/apache/shiro/config/ogdl/CommonsInterpolator.java
@@ -40,7 +40,7 @@ import org.apache.commons.configuration2.interpol.SystemPropertiesLookup;
  *     </tr>
  *     <tr>
  *         <td>env</td>
- *         <td>${EDITOR}</td>
+ *         <td>${EDITOR} (resolved from environment variables)</td>
  *         <td>vi</td>
  *     </tr>
  *     <tr>


### PR DESCRIPTION
The stated behavior is not the observed.

This is a complement to: https://github.com/apache/shiro-site/pull/82

The relevant section of the [commons-configuration class](https://commons.apache.org/proper/commons-configuration/apidocs/org/apache/commons/configuration2/interpol/ConfigurationInterpolator.html) is:

> After an instance has been created *it does not contain any Lookup objects*. The current set of lookup objects can be modified using the registerLookup() and deregisterLookup() methods. *Default lookup objects (that are invoked for variables without a prefix)* can be added or removed with the addDefaultLookup() and removeDefaultLookup() methods respectively. (When a ConfigurationInterpolator instance is created by a configuration object, a default lookup object is added pointing to the configuration itself, so that variables are resolved using the configuration's properties.)

So, the correct behavior is that you can use `${const:java.awt.event.KeyEvent.VK_ENTER}` but not `${env:EDITOR}`.  The current code accepts `${EDITOR}`. If a system property with this name is found not null, it is used, if not, an environment variable is search and if not, the whole substitution `${EDITOR}` is returned.


