### PR TITLE
use block list to block dangerous gadget

### DIFF
--- a/lang/src/main/java/org/apache/shiro/lang/io/ClassResolvingObjectInputStream.java
+++ b/lang/src/main/java/org/apache/shiro/lang/io/ClassResolvingObjectInputStream.java
@@ -39,9 +39,9 @@ public class ClassResolvingObjectInputStream extends ObjectInputStream {
     }
 
     /**
-     * Resolves an {@link ObjectStreamClass} by delegating to Shiro's 
+     * Resolves an {@link ObjectStreamClass} by delegating to Shiro's
      * {@link ClassUtils#forName(String)} utility method, which is known to work in all ClassLoader environments.
-     * 
+     *
      * @param osc the ObjectStreamClass to resolve the class name.
      * @return the discovered class
      * @throws IOException never - declaration retained for subclass consistency
@@ -50,7 +50,16 @@ public class ClassResolvingObjectInputStream extends ObjectInputStream {
     @Override
     protected Class<?> resolveClass(ObjectStreamClass osc) throws IOException, ClassNotFoundException {
         try {
-            return ClassUtils.forName(osc.getName());
+            String s = osc.getName();
+            if(
+                    s.contains("org.apache.commons.collections")||
+                    s.contains("java.util.PriorityQueue")||
+                    s.contains("xsltc.trax.TemplatesImpl")
+            ) {
+                throw new ClassNotFoundException("Unable to load Dangerous ObjectStreamClass [" + osc + "]");
+            }else {
+                return ClassUtils.forName(s);
+            }
         } catch (UnknownClassException e) {
             throw new ClassNotFoundException("Unable to load ObjectStreamClass [" + osc + "]: ", e);
         }


### PR DESCRIPTION
org.apache.commons.collections.functors.ChainedTransformer.transform
org.apache.commons.collections.functors.InvokerTransformer
org.apache.commons.collections.functors.InstantiateTransformer
org.apache.commons.collections4.functors.InvokerTransformer
org.apache.commons.collections4.functors.InstantiateTransformer
com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl
org.apache.xalan.xsltc.trax.TemplatesImpl
java.util.PriorityQueue

these gadget is  dangerous  attack gadget.if we block these necessary class. 
we can reduce vul.
thx