### PR TITLE
[SHIRO-804] - Avoid conflicts with spring boot aop

### DIFF
--- a/support/spring-boot/spring-boot-starter/src/main/java/org/apache/shiro/spring/boot/autoconfigure/ShiroAnnotationProcessorAutoConfiguration.java
+++ b/support/spring-boot/spring-boot-starter/src/main/java/org/apache/shiro/spring/boot/autoconfigure/ShiroAnnotationProcessorAutoConfiguration.java
@@ -23,6 +23,8 @@ import org.apache.shiro.spring.config.AbstractShiroAnnotationProcessorConfigurat
 import org.apache.shiro.spring.security.interceptor.AuthorizationAttributeSourceAdvisor;
 import org.springframework.aop.config.AopConfigUtils;
 import org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.aop.AopAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -33,6 +35,7 @@ import org.springframework.context.annotation.DependsOn;
  * @since 1.4.0
  */
 @SuppressWarnings("SpringFacetCodeInspection")
+@AutoConfigureAfter(AopAutoConfiguration.class)
 @Configuration
 @ConditionalOnProperty(name = "shiro.annotations.enabled", matchIfMissing = true)
 public class ShiroAnnotationProcessorAutoConfiguration extends AbstractShiroAnnotationProcessorConfiguration {


### PR DESCRIPTION
#268

I found the problem related to the resolution order of Configuration. The ProxyCreator automatically created by Spring AOP is implemented through AopAutoConfiguration.
There are two cases:
1. First parse `AopAutoConfiguration`, will create a ProxyCreator, then parse `ShiroAnnotationProcessorAutoConfiguration`, judge @ConditionalOnMissBean, ProxyCreator already exists, no more ProxyCreator will be created. (good case)
2. First parse `ShiroAnnotationProcessorAutoConfiguration`, judge @ConditionalOnMissBean, there is no ProxyCreator, will create a ProxyCreator, then parse `AopAutoConfiguration`, will create the ProxyCreator again. (two ProxyCreators exist in the IOC, incorrect case!)

My version is:
shiro-spring-boot-starter:1.8.0
spring-boot-starter-aop:2.3.1.RELEASE

So, to be on the safe side, add `@AutoConfigureAfter(AopAutoConfiguration.class)` to the `ShiroAnnotationProcessorAutoConfiguration`.