### PR TITLE
Fix SHIRO-881

### DIFF
--- a/samples/web/pom.xml
+++ b/samples/web/pom.xml
@@ -78,11 +78,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <scope>runtime</scope>
         </dependency>
@@ -105,6 +100,20 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${slf4j.version}</version>
+	    <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>apache-jsp</artifactId>
             <version>${jetty.version}</version>
@@ -122,7 +131,6 @@
             <artifactId>shiro-its-support</artifactId>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
 </project>


### PR DESCRIPTION
On mvn jetty:run in the samples/web,  java.lang.NoClassDefFoundError: org/apache/logging/log4j/spi/AbstractLoggerAdapter  shows up. This PR resolves the error.