### PR TITLE
Reduce the scope of the ThreadLocals used in SecurityManagerTestSupport

### DIFF
--- a/core/src/test/java/org/apache/shiro/authz/aop/PermissionAnnotationHandlerTest.java
+++ b/core/src/test/java/org/apache/shiro/authz/aop/PermissionAnnotationHandlerTest.java
@@ -56,7 +56,9 @@ public class PermissionAnnotationHandlerTest extends SecurityManagerTestSupport 
 	    }
         };
 
-        assertThrows(UnauthenticatedException.class, () -> handler.assertAuthorized(requiresPermissionAnnotation));
+        runWithSubject(subject -> {
+            assertThrows(UnauthenticatedException.class, () -> handler.assertAuthorized(requiresPermissionAnnotation));
+        });
     }
 
     //Added to satisfy SHIRO-146
@@ -82,7 +84,9 @@ public class PermissionAnnotationHandlerTest extends SecurityManagerTestSupport 
 	    }
         };
 
-        assertThrows(UnauthenticatedException.class, () -> handler.assertAuthorized(requiresPermissionAnnotation));
+        runWithSubject(subject -> {
+            assertThrows(UnauthenticatedException.class, () -> handler.assertAuthorized(requiresPermissionAnnotation));
+        });
     }
 
 }

--- a/core/src/test/java/org/apache/shiro/authz/aop/RoleAnnotationHandlerTest.java
+++ b/core/src/test/java/org/apache/shiro/authz/aop/RoleAnnotationHandlerTest.java
@@ -61,7 +61,9 @@ public class RoleAnnotationHandlerTest extends SecurityManagerTestSupport {
             }
         };
 
-        assertThrows(UnauthenticatedException.class, () -> handler.assertAuthorized(requiresRolesAnnotation));
+        runWithSubject(subject -> {
+            assertThrows(UnauthenticatedException.class, () -> handler.assertAuthorized(requiresRolesAnnotation));
+        });
     }
 
     //Added to satisfy SHIRO-146
@@ -87,7 +89,9 @@ public class RoleAnnotationHandlerTest extends SecurityManagerTestSupport {
             }
         };
 
-        assertThrows(UnauthenticatedException.class, () -> handler.assertAuthorized(requiresRolesAnnotation));
+        runWithSubject(subject -> {
+            assertThrows(UnauthenticatedException.class, () -> handler.assertAuthorized(requiresRolesAnnotation));
+        });
     }
 
     @Test

--- a/core/src/test/java/org/apache/shiro/concurrent/SubjectAwareExecutorServiceTest.java
+++ b/core/src/test/java/org/apache/shiro/concurrent/SubjectAwareExecutorServiceTest.java
@@ -47,11 +47,13 @@ public class SubjectAwareExecutorServiceTest extends SecurityManagerTestSupport 
 
         final SubjectAwareExecutorService executor = new SubjectAwareExecutorService(mockExecutorService);
 
-        Runnable testRunnable = () -> System.out.println("Hello World");
+        runWithSubject(subject -> {
+            Runnable testRunnable = () -> System.out.println("Hello World");
 
-        executor.submit(testRunnable);
-        SubjectRunnable subjectRunnable = captor.getValue();
-        Assertions.assertNotNull(subjectRunnable);
+            executor.submit(testRunnable);
+            SubjectRunnable subjectRunnable = captor.getValue();
+            Assertions.assertNotNull(subjectRunnable);
+        });
     }
 
     private static class DummyFuture<V> implements Future<V> {

--- a/core/src/test/java/org/apache/shiro/concurrent/SubjectAwareExecutorTest.java
+++ b/core/src/test/java/org/apache/shiro/concurrent/SubjectAwareExecutorTest.java
@@ -42,7 +42,7 @@ public class SubjectAwareExecutorTest extends SecurityManagerTestSupport {
         final SubjectAwareExecutor executor = new SubjectAwareExecutor(targetMockExecutor);
 
         Runnable work = () -> System.out.println("Hello World");
-        executor.execute(work);
+        runWithSubject(subject -> executor.execute(work));
 
         //* ensure the target Executor receives a SubjectRunnable instance that retains the subject identity:
         //(this is what verifies the test is valid):

--- a/web/src/test/groovy/org/apache/shiro/web/filter/authc/BearerHttpFilterAuthenticationTest.groovy
+++ b/web/src/test/groovy/org/apache/shiro/web/filter/authc/BearerHttpFilterAuthenticationTest.groovy
@@ -43,10 +43,12 @@ class BearerHttpFilterAuthenticationTest extends SecurityManagerTestSupport {
 
         HttpServletRequest request = mockRequest()
         HttpServletResponse response = mockResponse()
-        
-        AuthenticationToken token = testFilter.createToken(request, response)
-        assertThat(token, CoreMatchers.instanceOf(BearerToken.class))
-        assertThat(token.getPrincipal(), Matchers.is(""))
+
+        runWithSubject({
+            AuthenticationToken token = testFilter.createToken(request, response)
+            assertThat(token, CoreMatchers.instanceOf(BearerToken.class))
+            assertThat(token.getPrincipal(), Matchers.is(""))
+        })
 
         verify(request, response)
     }
@@ -57,10 +59,12 @@ class BearerHttpFilterAuthenticationTest extends SecurityManagerTestSupport {
 
         HttpServletRequest request = mockRequest("")
         HttpServletResponse response = mockResponse()
-        
-        AuthenticationToken token = testFilter.createToken(request, response)
-        assertThat(token, CoreMatchers.instanceOf(BearerToken.class))
-        assertThat(token.getPrincipal(), Matchers.is(""))
+
+        runWithSubject({
+            AuthenticationToken token = testFilter.createToken(request, response)
+            assertThat(token, CoreMatchers.instanceOf(BearerToken.class))
+            assertThat(token.getPrincipal(), Matchers.is(""))
+        })
 
         verify(request, response)
     }
@@ -72,9 +76,11 @@ class BearerHttpFilterAuthenticationTest extends SecurityManagerTestSupport {
         HttpServletRequest request = mockRequest("some-value")
         HttpServletResponse response = mockResponse()
 
-        AuthenticationToken token = testFilter.createToken(request, response)
-        assertThat(token, CoreMatchers.instanceOf(BearerToken.class))
-        assertThat(token.getPrincipal(), Matchers.is("some-value"))
+        runWithSubject({
+            AuthenticationToken token = testFilter.createToken(request, response)
+            assertThat(token, CoreMatchers.instanceOf(BearerToken.class))
+            assertThat(token.getPrincipal(), Matchers.is("some-value"))
+        })
 
         verify(request, response)
     }
@@ -86,9 +92,11 @@ class BearerHttpFilterAuthenticationTest extends SecurityManagerTestSupport {
         HttpServletRequest request = mockRequest("  ")
         HttpServletResponse response = mockResponse()
 
-        AuthenticationToken token = testFilter.createToken(request, response)
-        assertThat(token, CoreMatchers.instanceOf(BearerToken.class))
-        assertThat(token.getPrincipal(), Matchers.is(""))
+        runWithSubject({
+            AuthenticationToken token = testFilter.createToken(request, response)
+            assertThat(token, CoreMatchers.instanceOf(BearerToken.class))
+            assertThat(token.getPrincipal(), Matchers.is(""))
+        })
 
         verify(request, response)
     }
@@ -104,9 +112,11 @@ class BearerHttpFilterAuthenticationTest extends SecurityManagerTestSupport {
         HttpServletResponse response = createMock(HttpServletResponse.class)
         replay(response)
 
-        String[] methods =  [ "POST", "PUT", "DELETE" ]
-        boolean accessAllowed = testFilter.isAccessAllowed(request, response, methods)
-        assertThat("Access not allowed for GET", accessAllowed)
+        runWithSubject({
+            String[] methods = ["POST", "PUT", "DELETE"]
+            boolean accessAllowed = testFilter.isAccessAllowed(request, response, methods)
+            assertThat("Access not allowed for GET", accessAllowed)
+        })
         verify(request, response)
     }
     
@@ -120,9 +130,11 @@ class BearerHttpFilterAuthenticationTest extends SecurityManagerTestSupport {
         
         HttpServletResponse response = mockResponse()
 
-        String[] methods =  [ "POST", "PUT", "DELETE" ]
-        boolean accessAllowed = testFilter.isAccessAllowed(request, response, methods)
-        assertThat("Access allowed for POST", !accessAllowed)
+        runWithSubject({
+            String[] methods = ["POST", "PUT", "DELETE"]
+            boolean accessAllowed = testFilter.isAccessAllowed(request, response, methods)
+            assertThat("Access allowed for POST", !accessAllowed)
+        })
     }
 
     @Test
@@ -135,9 +147,11 @@ class BearerHttpFilterAuthenticationTest extends SecurityManagerTestSupport {
 
         HttpServletResponse response = mockResponse()
 
-        String[] mappedValue = ["permissive"]
-        boolean accessAllowed = testFilter.isAccessAllowed(request, response, mappedValue)
-        assertThat("Access allowed for GET", !accessAllowed) // login attempt should always be false
+        runWithSubject({
+            String[] mappedValue = ["permissive"]
+            boolean accessAllowed = testFilter.isAccessAllowed(request, response, mappedValue)
+            assertThat("Access allowed for GET", !accessAllowed) // login attempt should always be false
+        })
     }
 
     @Test
@@ -152,9 +166,11 @@ class BearerHttpFilterAuthenticationTest extends SecurityManagerTestSupport {
 
         HttpServletResponse response = mockResponse()
 
-        String[] mappedValue = ["permissive"]
-        boolean accessAllowed = testFilter.isAccessAllowed(request, response, mappedValue)
-        assertThat("Access should be allowed for GET", accessAllowed) // non-login attempt, return true
+        runWithSubject({
+            String[] mappedValue = ["permissive"]
+            boolean accessAllowed = testFilter.isAccessAllowed(request, response, mappedValue)
+            assertThat("Access should be allowed for GET", accessAllowed) // non-login attempt, return true
+        })
     }
 
     @Test
@@ -167,9 +183,11 @@ class BearerHttpFilterAuthenticationTest extends SecurityManagerTestSupport {
 
         HttpServletResponse response = mockResponse()
 
-        String[] mappedValue = ["permissive", "POST", "PUT", "DELETE" ]
-        boolean accessAllowed = testFilter.isAccessAllowed(request, response, mappedValue)
-        assertThat("Access allowed for POST", !accessAllowed)
+        runWithSubject({
+            String[] mappedValue = ["permissive", "POST", "PUT", "DELETE"]
+            boolean accessAllowed = testFilter.isAccessAllowed(request, response, mappedValue)
+            assertThat("Access allowed for POST", !accessAllowed)
+        })
     }
 
     static private String createAuthorizationHeader(String token) {

--- a/web/src/test/java/org/apache/shiro/web/filter/authz/AuthorizationFilterTest.java
+++ b/web/src/test/java/org/apache/shiro/web/filter/authz/AuthorizationFilterTest.java
@@ -18,10 +18,8 @@
  */
 package org.apache.shiro.web.filter.authz;
 
-import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.authc.UsernamePasswordToken;
 import org.apache.shiro.test.SecurityManagerTestSupport;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -29,7 +27,6 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -39,62 +36,63 @@ import static org.mockito.Mockito.when;
 /**
  * Test cases for the {@link AuthorizationFilter} class.
  */
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class AuthorizationFilterTest extends SecurityManagerTestSupport {
 
     @Test
-    @Disabled
-    public void testUserOnAccessDeniedWithResponseError() throws IOException {
+    public void testUserOnAccessDeniedWithResponseError() {
         // Tests when a user (known identity) is denied access and no unauthorizedUrl has been configured.
         // This should trigger an HTTP response error code.
 
         //log in the user using the account provided by the superclass for tests:
-        SecurityUtils.getSubject().login(new UsernamePasswordToken("test", "test"));
+        runWithSubject(subject -> {
+            subject.login(new UsernamePasswordToken("test", "test"));
         
-        AuthorizationFilter filter = new AuthorizationFilter() {
-            @Override
-            protected boolean isAccessAllowed(ServletRequest request, ServletResponse response, Object mappedValue) {
-                return false; //for this test case
-            }
-        };
+            AuthorizationFilter filter = new AuthorizationFilter() {
+                @Override
+                protected boolean isAccessAllowed(ServletRequest request, ServletResponse response, Object mappedValue) {
+                    return false; //for this test case
+                }
+            };
 
-        HttpServletRequest request = mock(HttpServletRequest.class);
-        HttpServletResponse response = mock(HttpServletResponse.class);
+            HttpServletRequest request = mock(HttpServletRequest.class);
+            HttpServletResponse response = mock(HttpServletResponse.class);
 
-        // response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
-        filter.onAccessDenied(request, response);
-        verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            // response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            filter.onAccessDenied(request, response);
+            verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        });
     }
 
     @Test
-    @Disabled
-    public void testUserOnAccessDeniedWithRedirect() throws IOException {
+    public void testUserOnAccessDeniedWithRedirect() {
         // Tests when a user (known identity) is denied access and an unauthorizedUrl *has* been configured.
         // This should trigger an HTTP redirect
 
         //log in the user using the account provided by the superclass for tests:
-        SecurityUtils.getSubject().login(new UsernamePasswordToken("test", "test"));
+        runWithSubject(subject -> {
+            subject.login(new UsernamePasswordToken("test", "test"));
 
-        String unauthorizedUrl = "unauthorized.jsp";
+            String unauthorizedUrl = "unauthorized.jsp";
 
-        AuthorizationFilter filter = new AuthorizationFilter() {
-            @Override
-            protected boolean isAccessAllowed(ServletRequest request, ServletResponse response, Object mappedValue) {
-                return false; //for this test case
-            }
-        };
-        filter.setUnauthorizedUrl(unauthorizedUrl);
+            AuthorizationFilter filter = new AuthorizationFilter() {
+                @Override
+                protected boolean isAccessAllowed(ServletRequest request, ServletResponse response, Object mappedValue) {
+                    return false; //for this test case
+                }
+            };
+            filter.setUnauthorizedUrl(unauthorizedUrl);
 
-        HttpServletRequest request = mock(HttpServletRequest.class);
-        HttpServletResponse response = mock(HttpServletResponse.class);
+            HttpServletRequest request = mock(HttpServletRequest.class);
+            HttpServletResponse response = mock(HttpServletResponse.class);
 
-        String encoded = "/" + unauthorizedUrl;
-        when(response.encodeRedirectURL(unauthorizedUrl)).thenReturn(encoded);
-        response.sendRedirect(encoded);
+            String encoded = "/" + unauthorizedUrl;
+            when(response.encodeRedirectURL(unauthorizedUrl)).thenReturn(encoded);
+            response.sendRedirect(encoded);
 
-        filter.onAccessDenied(request, response);
+            filter.onAccessDenied(request, response);
 
-        verify(response, atLeastOnce()).sendRedirect(encoded);
-        verify(response).encodeRedirectURL(unauthorizedUrl);
+            verify(response, atLeastOnce()).sendRedirect(encoded);
+            verify(response).encodeRedirectURL(unauthorizedUrl);
+        });
     }
 }


### PR DESCRIPTION
Individual test methods can scope the usage of a SecurityManger and Subject to specific methods.

Related to: #361