### PR TITLE
[SHIRO-884] use plugin version from parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1524,7 +1524,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>


### PR DESCRIPTION
I just removed the plugin version to simply inherit from parent plugin management

but I don't see why this doc profile is used given the work is already done by the apache-release profile: another fix would basically to fully remove this profile