### PR TITLE
update guava 1 10 x

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -37,6 +37,7 @@
         <japicmp.skip>true</japicmp.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
         <nexus.deploy.skip>true</nexus.deploy.skip>
+        <skipItDepCheck>false</skipItDepCheck>
     </properties>
 
     <modules>
@@ -45,6 +46,17 @@
         <module>guice4</module>
     </modules>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <configuration>
+                    <skip>${skipItDepCheck}</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <reporting>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1193,6 +1193,11 @@
                 <version>${guice.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>31.1-jre</version>
+            </dependency>
+            <dependency>
                 <groupId>com.google.inject.extensions</groupId>
                 <artifactId>guice-multibindings</artifactId>
                 <version>${guice.version}</version>


### PR DESCRIPTION
- Update guava to 31.1
- Add optional flag to skip dependency check for integration tets
