### PR TITLE
Revert: Bump maven-project-info-reports-plugin from 3.1.2 to 3.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1288,7 +1288,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.1.2</version>
                 <!-- Disable, just to make it go faster -->
                 <configuration>
                     <dependencyLocationsEnabled>false</dependencyLocationsEnabled>


### PR DESCRIPTION
The newer version attempts to resolve dependencies that are not available (or use in a report)
