### PR TITLE
[SHIRO-890] Avoid another proxy creator when @EnableAspectJAutoProxy enabled (backport 1.1.0.x)

### DIFF
--- a/support/spring-boot/spring-boot-starter/pom.xml
+++ b/support/spring-boot/spring-boot-starter/pom.xml
@@ -82,7 +82,11 @@
             <version>${commons.logging.version}</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjweaver</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/support/spring-boot/spring-boot-starter/src/main/java/org/apache/shiro/spring/boot/autoconfigure/ShiroAnnotationProcessorAutoConfiguration.java
+++ b/support/spring-boot/spring-boot-starter/src/main/java/org/apache/shiro/spring/boot/autoconfigure/ShiroAnnotationProcessorAutoConfiguration.java
@@ -21,7 +21,10 @@ package org.apache.shiro.spring.boot.autoconfigure;
 import org.apache.shiro.mgt.SecurityManager;
 import org.apache.shiro.spring.config.AbstractShiroAnnotationProcessorConfiguration;
 import org.apache.shiro.spring.security.interceptor.AuthorizationAttributeSourceAdvisor;
+import org.springframework.aop.config.AopConfigUtils;
 import org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.aop.AopAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -32,13 +35,14 @@ import org.springframework.context.annotation.DependsOn;
  * @since 1.4.0
  */
 @SuppressWarnings("SpringFacetCodeInspection")
+@AutoConfigureAfter(AopAutoConfiguration.class)
 @Configuration
 @ConditionalOnProperty(name = "shiro.annotations.enabled", matchIfMissing = true)
 public class ShiroAnnotationProcessorAutoConfiguration extends AbstractShiroAnnotationProcessorConfiguration {
 
     @Bean
     @DependsOn("lifecycleBeanPostProcessor")
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(name = AopConfigUtils.AUTO_PROXY_CREATOR_BEAN_NAME)
     @Override
     public DefaultAdvisorAutoProxyCreator defaultAdvisorAutoProxyCreator() {
         return super.defaultAdvisorAutoProxyCreator();

--- a/support/spring-boot/spring-boot-starter/src/test/groovy/org/apache/shiro/spring/boot/autoconfigure/AspectjAndDefaultProxyCreatorTest.groovy
+++ b/support/spring-boot/spring-boot-starter/src/test/groovy/org/apache/shiro/spring/boot/autoconfigure/AspectjAndDefaultProxyCreatorTest.groovy
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.spring.boot.autoconfigure;
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.aop.aspectj.annotation.AnnotationAwareAspectJAutoProxyCreator
+import org.springframework.aop.config.AopConfigUtils
+import org.springframework.aop.framework.autoproxy.AbstractAdvisorAutoProxyCreator
+import org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator
+import org.springframework.beans.BeansException
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
+
+import static org.hamcrest.Matchers.*
+import static org.hamcrest.MatcherAssert.assertThat
+
+@SpringBootTest(classes = AspectjAndDefaultProxyCreatorApplication.class)
+@RunWith(SpringJUnit4ClassRunner.class)
+class AspectjAndDefaultProxyCreatorTest {
+
+    @Autowired
+    private ApplicationContext applicationContext
+
+    @Test
+    void defaultAdvisorAutoProxyCreator() throws BeansException {
+        // There are two proxy creators before SHIRO-890 which causes problem when @EnableAspectJAutoProxy is enabled.
+        String[] names = ["defaultAdvisorAutoProxyCreator", AopConfigUtils.AUTO_PROXY_CREATOR_BEAN_NAME]
+        for (String name : names) {
+            Object creator = applicationContext.getBean(name)
+            assertThat(creator, anyOf(
+                    instanceOf(DefaultAdvisorAutoProxyCreator.class),
+                    instanceOf(AnnotationAwareAspectJAutoProxyCreator.class)
+            ))
+        }
+        String[] beanNames = applicationContext.getBeanNamesForType(AbstractAdvisorAutoProxyCreator.class)
+        assertThat(names, arrayContainingInAnyOrder(beanNames))
+    }
+}

--- a/support/spring-boot/spring-boot-starter/src/test/groovy/org/apache/shiro/spring/boot/autoconfigure/ShiroAnnotationProcessorAutoConfigurationTest.groovy
+++ b/support/spring-boot/spring-boot-starter/src/test/groovy/org/apache/shiro/spring/boot/autoconfigure/ShiroAnnotationProcessorAutoConfigurationTest.groovy
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.spring.boot.autoconfigure;
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.aop.aspectj.annotation.AnnotationAwareAspectJAutoProxyCreator
+import org.springframework.aop.config.AopConfigUtils
+import org.springframework.aop.framework.autoproxy.AbstractAdvisorAutoProxyCreator
+import org.springframework.beans.BeansException
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.*
+
+@SpringBootTest(classes = AspectjEnabledApplication.class)
+@RunWith(SpringJUnit4ClassRunner.class)
+class ShiroAnnotationProcessorAutoConfigurationTest {
+
+    @Autowired
+    private ApplicationContext applicationContext
+
+    @Test
+    void defaultAdvisorAutoProxyCreator() throws BeansException {
+        //  There is only one proxy creator, and it's AnnotationAwareAspectJAutoProxyCreator as expected.
+        Object creator = applicationContext.getBean(AopConfigUtils.AUTO_PROXY_CREATOR_BEAN_NAME)
+        assertThat("@EnableAspectJAutoProxy will create an instance of AnnotationAwareAspectJAutoProxyCreator",
+                creator, instanceOf(AnnotationAwareAspectJAutoProxyCreator.class))
+        String[] names = applicationContext.getBeanNamesForType(AbstractAdvisorAutoProxyCreator.class)
+        assertThat(names, arrayWithSize(1))
+    }
+}

--- a/support/spring-boot/spring-boot-starter/src/test/java/org/apache/shiro/spring/boot/autoconfigure/AspectjAndDefaultProxyCreatorApplication.java
+++ b/support/spring-boot/spring-boot-starter/src/test/java/org/apache/shiro/spring/boot/autoconfigure/AspectjAndDefaultProxyCreatorApplication.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.spring.boot.autoconfigure;
+
+import org.apache.shiro.realm.Realm;
+import org.apache.shiro.realm.text.TextConfigurationRealm;
+import org.springframework.aop.config.AopConfigUtils;
+import org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+@EnableAutoConfiguration
+@EnableAspectJAutoProxy
+public class AspectjAndDefaultProxyCreatorApplication {
+
+    public static void main(String... args) {
+        SpringApplication.run(AspectjAndDefaultProxyCreatorApplication.class);
+    }
+
+    @Bean
+    @SuppressWarnings("Duplicates")
+    Realm getTextConfigurationRealm() {
+
+        TextConfigurationRealm realm = new TextConfigurationRealm();
+        realm.setUserDefinitions("joe.coder=password,user\n" +
+                "jill.coder=password,admin");
+
+        realm.setRoleDefinitions("admin=read,write\n" +
+                "user=read");
+        realm.setCachingEnabled(true);
+        return realm;
+    }
+
+    @Bean
+    @DependsOn("lifecycleBeanPostProcessor")
+    @ConditionalOnMissingBean(value = DefaultAdvisorAutoProxyCreator.class, name = AopConfigUtils.AUTO_PROXY_CREATOR_BEAN_NAME)
+    public DefaultAdvisorAutoProxyCreator defaultAdvisorAutoProxyCreator() {
+        return new DefaultAdvisorAutoProxyCreator();
+    }
+}

--- a/support/spring-boot/spring-boot-starter/src/test/java/org/apache/shiro/spring/boot/autoconfigure/AspectjEnabledApplication.java
+++ b/support/spring-boot/spring-boot-starter/src/test/java/org/apache/shiro/spring/boot/autoconfigure/AspectjEnabledApplication.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.spring.boot.autoconfigure;
+
+import org.apache.shiro.realm.Realm;
+import org.apache.shiro.realm.text.TextConfigurationRealm;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+@EnableAutoConfiguration
+@EnableAspectJAutoProxy
+public class AspectjEnabledApplication {
+
+    public static void main(String... args) {
+        SpringApplication.run(AspectjEnabledApplication.class);
+    }
+
+    @Bean
+    @SuppressWarnings("Duplicates")
+    Realm getTextConfigurationRealm() {
+
+        TextConfigurationRealm realm = new TextConfigurationRealm();
+        realm.setUserDefinitions("joe.coder=password,user\n" +
+                "jill.coder=password,admin");
+
+        realm.setRoleDefinitions("admin=read,write\n" +
+                "user=read");
+        realm.setCachingEnabled(true);
+        return realm;
+    }
+}


### PR DESCRIPTION
- Avoid another proxy creator when @EnableAspectJAutoProxy enabled
- Add unit tests for SHIRO-890
- Add licenses
- Fix typos in unit tests
- cleaning up whitespace
- Migrate aop tests to groovy
