### PR TITLE
fix(sec): upgrade org.eclipse.jetty:jetty-server to 9.4.41

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <hsqldb.version>2.5.0</hsqldb.version>
         <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
         <jdk.version>1.8</jdk.version>
-        <jetty.version>9.4.34.v20201102</jetty.version>
+        <jetty.version>9.4.41</jetty.version>
         <owasp.java.encoder.version>1.2.3</owasp.java.encoder.version>
         <!-- Don't change this version without also changing the shiro-quartz and shiro-features
              modules' OSGi metadata: -->


### PR DESCRIPTION
### What happened？
There are 3 security vulnerabilities found in org.eclipse.jetty:jetty-server 9.4.34.v20201102
- [CVE-2021-34428](https://www.oscs1024.com/hd/CVE-2021-34428)
- [CVE-2020-27218](https://www.oscs1024.com/hd/CVE-2020-27218)
- [CVE-2020-27223](https://www.oscs1024.com/hd/CVE-2020-27223)


### What did I do？
Upgrade org.eclipse.jetty:jetty-server from 9.4.34.v20201102 to 9.4.41 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS