### PR TITLE
[SHIRO-893] - Fix NPE in ShiroFilter.init()

### DIFF
--- a/web/src/main/java/org/apache/shiro/web/env/DefaultWebEnvironment.java
+++ b/web/src/main/java/org/apache/shiro/web/env/DefaultWebEnvironment.java
@@ -39,8 +39,6 @@ public class DefaultWebEnvironment extends DefaultEnvironment implements Mutable
 
     private ServletContext servletContext;
 
-    private ShiroFilterConfiguration filterConfiguration;
-
     public DefaultWebEnvironment() {
         super();
     }
@@ -97,6 +95,12 @@ public class DefaultWebEnvironment extends DefaultEnvironment implements Mutable
 
     @Override
     public ShiroFilterConfiguration getShiroFilterConfiguration() {
-        return getObject(SHIRO_FILTER_CONFIG_NAME, ShiroFilterConfiguration.class);
+        ShiroFilterConfiguration config = getObject(SHIRO_FILTER_CONFIG_NAME, ShiroFilterConfiguration.class);
+        // Use the default configuration if config is null
+        if (config == null) {
+            config = MutableWebEnvironment.super.getShiroFilterConfiguration();
+            setShiroFilterConfiguration(config);
+        }
+        return config;
     }
 }

--- a/web/src/test/java/org/apache/shiro/web/env/EnvironmentLoaderServiceTest.java
+++ b/web/src/test/java/org/apache/shiro/web/env/EnvironmentLoaderServiceTest.java
@@ -30,6 +30,8 @@ import java.io.InputStream;
 import static org.easymock.EasyMock.expect;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.Matchers.stringContainsInOrder;
 
@@ -58,6 +60,24 @@ public class EnvironmentLoaderServiceTest {
         IniWebEnvironment environmentStub = (IniWebEnvironment) resultEnvironment;
 
         assertThat(environmentStub.getServletContext(), sameInstance(servletContext));
+    }
+
+    @Test
+    public void testDefaultWebEnvironment() {
+        ServletContext servletContext = EasyMock.mock(ServletContext.class);
+        expect(servletContext.getInitParameter("shiroEnvironmentClass"))
+                .andReturn(DefaultWebEnvironment.class.getName());
+        expect(servletContext.getInitParameter("shiroConfigLocations")).andReturn(null);
+
+        EasyMock.replay(servletContext);
+
+        WebEnvironment environment = new EnvironmentLoader().createEnvironment(servletContext);
+
+        EasyMock.verify(servletContext);
+
+        assertThat(environment, instanceOf(DefaultWebEnvironment.class));
+        assertThat(environment.getShiroFilterConfiguration(), is(notNullValue()));
+        assertThat(environment.getServletContext(), sameInstance(servletContext));
     }
 
     @Test()


### PR DESCRIPTION
Fixes [SHIRO-893](https://issues.apache.org/jira/browse/SHIRO-893).

In 1.10.0, an NPE can be thrown because DefaultWebEnvironment has no default value for ShiroFilterConfiguration. This commit adds a default value determined by WebEnvironment.getShiroFilterConfiguration().

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
