### PR TITLE
Allow for direct configuration of ShiroFilter through WebEnvironment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -415,6 +415,7 @@
                             <onlyModified>true</onlyModified>
                             <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
                             <breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>
+                            <postAnalysisScript>${root.dir}/src/japicmp/postAnalysisScript.groovy</postAnalysisScript>
                         </parameter>
                     </configuration>
                 </plugin>

--- a/samples/servlet-plugin/pom.xml
+++ b/samples/servlet-plugin/pom.xml
@@ -106,13 +106,8 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/src/japicmp/postAnalysisScript.groovy
+++ b/src/japicmp/postAnalysisScript.groovy
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import static japicmp.model.JApiCompatibilityChange.*
+import static japicmp.model.JApiChangeStatus.*
+
+def it = jApiClasses.iterator()
+while (it.hasNext()) {
+    def jApiClass = it.next()
+    // filter out interfaces changes that are default methods
+    if (jApiClass.getChangeStatus() != UNCHANGED) {
+        def methodIt = jApiClass.getMethods().iterator()
+        while (methodIt.hasNext()) {
+            def method = methodIt.next()
+            def methodChanges = method.getCompatibilityChanges()
+            methodChanges.remove(METHOD_NEW_DEFAULT)
+        }
+    }
+}
+return jApiClasses

--- a/support/guice/src/main/java/org/apache/shiro/guice/web/GuiceShiroFilter.java
+++ b/support/guice/src/main/java/org/apache/shiro/guice/web/GuiceShiroFilter.java
@@ -18,6 +18,7 @@
  */
 package org.apache.shiro.guice.web;
 
+import org.apache.shiro.web.config.ShiroFilterConfiguration;
 import org.apache.shiro.web.filter.mgt.FilterChainResolver;
 import org.apache.shiro.web.mgt.WebSecurityManager;
 import org.apache.shiro.web.servlet.AbstractShiroFilter;
@@ -31,8 +32,9 @@ import javax.inject.Inject;
  */
 public class GuiceShiroFilter extends AbstractShiroFilter {
     @Inject
-    GuiceShiroFilter(WebSecurityManager webSecurityManager, FilterChainResolver filterChainResolver) {
+    GuiceShiroFilter(WebSecurityManager webSecurityManager, FilterChainResolver filterChainResolver, ShiroFilterConfiguration filterConfiguration) {
         this.setSecurityManager(webSecurityManager);
         this.setFilterChainResolver(filterChainResolver);
+        this.setShiroFilterConfiguration(filterConfiguration);
     }
 }

--- a/support/guice/src/main/java/org/apache/shiro/guice/web/WebGuiceEnvironment.java
+++ b/support/guice/src/main/java/org/apache/shiro/guice/web/WebGuiceEnvironment.java
@@ -21,6 +21,7 @@ package org.apache.shiro.guice.web;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.apache.shiro.mgt.SecurityManager;
+import org.apache.shiro.web.config.ShiroFilterConfiguration;
 import org.apache.shiro.web.env.EnvironmentLoaderListener;
 import org.apache.shiro.web.env.WebEnvironment;
 import org.apache.shiro.web.filter.mgt.FilterChainResolver;
@@ -35,11 +36,14 @@ class WebGuiceEnvironment implements WebEnvironment {
     private ServletContext servletContext;
     private WebSecurityManager securityManager;
 
+    private ShiroFilterConfiguration filterConfiguration;
+
     @Inject
-    WebGuiceEnvironment(FilterChainResolver filterChainResolver, @Named(ShiroWebModule.NAME) ServletContext servletContext, WebSecurityManager securityManager) {
+    WebGuiceEnvironment(FilterChainResolver filterChainResolver, @Named(ShiroWebModule.NAME) ServletContext servletContext, WebSecurityManager securityManager, ShiroFilterConfiguration filterConfiguration) {
         this.filterChainResolver = filterChainResolver;
         this.servletContext = servletContext;
         this.securityManager = securityManager;
+        this.filterConfiguration = filterConfiguration;
 
         servletContext.setAttribute(EnvironmentLoaderListener.ENVIRONMENT_ATTRIBUTE_KEY, this);
     }
@@ -58,5 +62,9 @@ class WebGuiceEnvironment implements WebEnvironment {
 
     public SecurityManager getSecurityManager() {
         return securityManager;
+    }
+
+    public ShiroFilterConfiguration getShiroFilterConfiguration() {
+        return filterConfiguration;
     }
 }

--- a/support/guice/src/test/java/org/apache/shiro/guice/web/GuiceShiroFilterTest.java
+++ b/support/guice/src/test/java/org/apache/shiro/guice/web/GuiceShiroFilterTest.java
@@ -19,13 +19,13 @@
 package org.apache.shiro.guice.web;
 
 import com.google.inject.spi.InjectionPoint;
+import org.apache.shiro.web.config.ShiroFilterConfiguration;
 import org.apache.shiro.web.filter.mgt.FilterChainResolver;
 import org.apache.shiro.web.mgt.WebSecurityManager;
 import org.junit.Test;
 
-import static org.easymock.EasyMock.createMock;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
 
 public class GuiceShiroFilterTest {
 
@@ -42,10 +42,17 @@ public class GuiceShiroFilterTest {
     public void testConstructor() {
         WebSecurityManager securityManager = createMock(WebSecurityManager.class);
         FilterChainResolver filterChainResolver = createMock(FilterChainResolver.class);
+        ShiroFilterConfiguration filterConfiguration = createMock(ShiroFilterConfiguration.class);
+        expect(filterConfiguration.isStaticSecurityManagerEnabled()).andReturn(true);
+        expect(filterConfiguration.isFilterOncePerRequest()).andReturn(false);
 
-        GuiceShiroFilter underTest = new GuiceShiroFilter(securityManager, filterChainResolver);
+        replay(securityManager, filterChainResolver, filterConfiguration);
+
+        GuiceShiroFilter underTest = new GuiceShiroFilter(securityManager, filterChainResolver, filterConfiguration);
 
         assertSame(securityManager, underTest.getSecurityManager());
         assertSame(filterChainResolver, underTest.getFilterChainResolver());
+        assertTrue(underTest.isStaticSecurityManagerEnabled());
+        assertFalse(underTest.isFilterOncePerRequest());
     }
 }

--- a/support/guice/src/test/java/org/apache/shiro/guice/web/GuiceShiroFilterTest.java
+++ b/support/guice/src/test/java/org/apache/shiro/guice/web/GuiceShiroFilterTest.java
@@ -24,15 +24,19 @@ import org.apache.shiro.web.filter.mgt.FilterChainResolver;
 import org.apache.shiro.web.mgt.WebSecurityManager;
 import org.junit.Test;
 
-import static org.easymock.EasyMock.*;
-import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.when;
 
 public class GuiceShiroFilterTest {
 
     @Test
     public void ensureInjectable() {
         try {
-            InjectionPoint ip = InjectionPoint.forConstructorOf(GuiceShiroFilter.class);
+            InjectionPoint.forConstructorOf(GuiceShiroFilter.class);
         } catch (Exception e) {
             fail("Could not create constructor injection point.");
         }
@@ -40,13 +44,11 @@ public class GuiceShiroFilterTest {
 
     @Test
     public void testConstructor() {
-        WebSecurityManager securityManager = createMock(WebSecurityManager.class);
-        FilterChainResolver filterChainResolver = createMock(FilterChainResolver.class);
-        ShiroFilterConfiguration filterConfiguration = createMock(ShiroFilterConfiguration.class);
-        expect(filterConfiguration.isStaticSecurityManagerEnabled()).andReturn(true);
-        expect(filterConfiguration.isFilterOncePerRequest()).andReturn(false);
-
-        replay(securityManager, filterChainResolver, filterConfiguration);
+        WebSecurityManager securityManager = mock(WebSecurityManager.class);
+        FilterChainResolver filterChainResolver = mock(FilterChainResolver.class);
+        ShiroFilterConfiguration filterConfiguration = mock(ShiroFilterConfiguration.class);
+        when(filterConfiguration.isStaticSecurityManagerEnabled()).thenReturn(true);
+        when(filterConfiguration.isFilterOncePerRequest()).thenReturn(false);
 
         GuiceShiroFilter underTest = new GuiceShiroFilter(securityManager, filterChainResolver, filterConfiguration);
 

--- a/support/guice/src/test/java/org/apache/shiro/guice/web/ShiroWebModuleTest.java
+++ b/support/guice/src/test/java/org/apache/shiro/guice/web/ShiroWebModuleTest.java
@@ -30,6 +30,7 @@ import org.apache.shiro.env.Environment;
 import org.apache.shiro.mgt.SecurityManager;
 import org.apache.shiro.realm.Realm;
 import org.apache.shiro.session.mgt.SessionManager;
+import org.apache.shiro.web.config.ShiroFilterConfiguration;
 import org.apache.shiro.web.env.EnvironmentLoader;
 import org.apache.shiro.web.env.WebEnvironment;
 import org.apache.shiro.web.filter.InvalidRequestFilter;
@@ -487,8 +488,8 @@ public class ShiroWebModuleTest {
 
     public static class MyWebEnvironment extends WebGuiceEnvironment {
         @Inject
-        MyWebEnvironment(FilterChainResolver filterChainResolver, @Named(ShiroWebModule.NAME) ServletContext servletContext, WebSecurityManager securityManager) {
-            super(filterChainResolver, servletContext, securityManager);
+        MyWebEnvironment(FilterChainResolver filterChainResolver, @Named(ShiroWebModule.NAME) ServletContext servletContext, WebSecurityManager securityManager, ShiroFilterConfiguration filterConfiguration) {
+            super(filterChainResolver, servletContext, securityManager, filterConfiguration);
         }
     }
 

--- a/support/guice/src/test/java/org/apache/shiro/guice/web/WebGuiceEnvironmentTest.java
+++ b/support/guice/src/test/java/org/apache/shiro/guice/web/WebGuiceEnvironmentTest.java
@@ -19,6 +19,7 @@
 package org.apache.shiro.guice.web;
 
 import com.google.inject.spi.InjectionPoint;
+import org.apache.shiro.web.config.ShiroFilterConfiguration;
 import org.apache.shiro.web.env.EnvironmentLoaderListener;
 import org.apache.shiro.web.filter.mgt.FilterChainResolver;
 import org.apache.shiro.web.mgt.WebSecurityManager;
@@ -47,13 +48,14 @@ public class WebGuiceEnvironmentTest {
         WebSecurityManager securityManager = createMock(WebSecurityManager.class);
         FilterChainResolver filterChainResolver = createMock(FilterChainResolver.class);
         ServletContext servletContext = createMock(ServletContext.class);
+        ShiroFilterConfiguration filterConfiguration = createMock(ShiroFilterConfiguration.class);
 
         Capture<WebGuiceEnvironment> capture = Capture.newInstance();
         servletContext.setAttribute(eq(EnvironmentLoaderListener.ENVIRONMENT_ATTRIBUTE_KEY), and(anyObject(WebGuiceEnvironment.class), capture(capture)));
 
         replay(servletContext, securityManager, filterChainResolver);
 
-        WebGuiceEnvironment underTest = new WebGuiceEnvironment(filterChainResolver, servletContext, securityManager);
+        WebGuiceEnvironment underTest = new WebGuiceEnvironment(filterChainResolver, servletContext, securityManager, filterConfiguration);
 
         assertSame(securityManager, underTest.getSecurityManager());
         assertSame(filterChainResolver, underTest.getFilterChainResolver());

--- a/support/spring/src/main/java/org/apache/shiro/spring/web/ShiroFilterFactoryBean.java
+++ b/support/spring/src/main/java/org/apache/shiro/spring/web/ShiroFilterFactoryBean.java
@@ -24,6 +24,7 @@ import org.apache.shiro.util.CollectionUtils;
 import org.apache.shiro.lang.util.Nameable;
 import org.apache.shiro.lang.util.StringUtils;
 import org.apache.shiro.web.config.IniFilterChainResolverFactory;
+import org.apache.shiro.web.config.ShiroFilterConfiguration;
 import org.apache.shiro.web.filter.AccessControlFilter;
 import org.apache.shiro.web.filter.InvalidRequestFilter;
 import org.apache.shiro.web.filter.authc.AuthenticationFilter;
@@ -35,6 +36,7 @@ import org.apache.shiro.web.filter.mgt.FilterChainResolver;
 import org.apache.shiro.web.filter.mgt.PathMatchingFilterChainResolver;
 import org.apache.shiro.web.mgt.WebSecurityManager;
 import org.apache.shiro.web.servlet.AbstractShiroFilter;
+import org.apache.shiro.web.servlet.OncePerRequestFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
@@ -135,15 +137,18 @@ public class ShiroFilterFactoryBean implements FactoryBean, BeanPostProcessor {
 
     private AbstractShiroFilter instance;
 
+    private ShiroFilterConfiguration filterConfiguration;
+
     public ShiroFilterFactoryBean() {
         this.filters = new LinkedHashMap<String, Filter>();
         this.globalFilters = new ArrayList<>();
         this.globalFilters.add(DefaultFilter.invalidRequest.name());
         this.filterChainDefinitionMap = new LinkedHashMap<String, String>(); //order matters!
+        this.filterConfiguration = new ShiroFilterConfiguration();
     }
 
     /**
-     * Sets the application {@code SecurityManager} instance to be used by the constructed Shiro Filter.  This is a
+     * Gets the application {@code SecurityManager} instance to be used by the constructed Shiro Filter.  This is a
      * required property - failure to set it will throw an initialization exception.
      *
      * @return the application {@code SecurityManager} instance to be used by the constructed Shiro Filter.
@@ -160,6 +165,24 @@ public class ShiroFilterFactoryBean implements FactoryBean, BeanPostProcessor {
      */
     public void setSecurityManager(SecurityManager securityManager) {
         this.securityManager = securityManager;
+    }
+
+    /**
+     * Gets the application {@code ShiroFilterConfiguration} instance to be used by the constructed Shiro Filter.
+     *
+     * @return the application {@code ShiroFilterConfiguration} instance to be used by the constructed Shiro Filter.
+     */
+    public ShiroFilterConfiguration getShiroFilterConfiguration() {
+        return filterConfiguration;
+    }
+
+    /**
+     * Sets the application {@code ShiroFilterConfiguration} instance to be used by the constructed Shiro Filter.
+     *
+     * @param filterConfiguration the application {@code SecurityManager} instance to be used by the constructed Shiro Filter.
+     */
+    public void setShiroFilterConfiguration(ShiroFilterConfiguration filterConfiguration) {
+        this.filterConfiguration = filterConfiguration;
     }
 
     /**
@@ -468,7 +491,7 @@ public class ShiroFilterFactoryBean implements FactoryBean, BeanPostProcessor {
         //FilterChainResolver.  It doesn't matter that the instance is an anonymous inner class
         //here - we're just using it because it is a concrete AbstractShiroFilter instance that accepts
         //injection of the SecurityManager and FilterChainResolver:
-        return new SpringShiroFilter((WebSecurityManager) securityManager, chainResolver);
+        return new SpringShiroFilter((WebSecurityManager) securityManager, chainResolver, getShiroFilterConfiguration());
     }
 
     private void applyLoginUrlIfNecessary(Filter filter) {
@@ -511,6 +534,10 @@ public class ShiroFilterFactoryBean implements FactoryBean, BeanPostProcessor {
         applyLoginUrlIfNecessary(filter);
         applySuccessUrlIfNecessary(filter);
         applyUnauthorizedUrlIfNecessary(filter);
+
+        if (filter instanceof OncePerRequestFilter) {
+            ((OncePerRequestFilter) filter).setFilterOncePerRequest(filterConfiguration.isFilterOncePerRequest());
+        }
     }
 
     /**
@@ -549,12 +576,13 @@ public class ShiroFilterFactoryBean implements FactoryBean, BeanPostProcessor {
      */
     private static final class SpringShiroFilter extends AbstractShiroFilter {
 
-        protected SpringShiroFilter(WebSecurityManager webSecurityManager, FilterChainResolver resolver) {
+        protected SpringShiroFilter(WebSecurityManager webSecurityManager, FilterChainResolver resolver, ShiroFilterConfiguration filterConfiguration) {
             super();
             if (webSecurityManager == null) {
                 throw new IllegalArgumentException("WebSecurityManager property cannot be null.");
             }
             setSecurityManager(webSecurityManager);
+            setShiroFilterConfiguration(filterConfiguration);
 
             if (resolver != null) {
                 setFilterChainResolver(resolver);

--- a/support/spring/src/main/java/org/apache/shiro/spring/web/config/AbstractShiroWebFilterConfiguration.java
+++ b/support/spring/src/main/java/org/apache/shiro/spring/web/config/AbstractShiroWebFilterConfiguration.java
@@ -20,6 +20,7 @@ package org.apache.shiro.spring.web.config;
 
 import org.apache.shiro.mgt.SecurityManager;
 import org.apache.shiro.spring.web.ShiroFilterFactoryBean;
+import org.apache.shiro.web.config.ShiroFilterConfiguration;
 import org.apache.shiro.web.filter.mgt.DefaultFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -41,6 +42,9 @@ public class AbstractShiroWebFilterConfiguration {
     protected ShiroFilterChainDefinition shiroFilterChainDefinition;
 
     @Autowired(required = false)
+    protected ShiroFilterConfiguration shiroFilterConfiguration;
+
+    @Autowired(required = false)
     protected Map<String, Filter> filterMap;
 
     @Value("#{ @environment['shiro.loginUrl'] ?: '/login.jsp' }")
@@ -56,6 +60,12 @@ public class AbstractShiroWebFilterConfiguration {
         return Collections.singletonList(DefaultFilter.invalidRequest.name());
     }
 
+    protected ShiroFilterConfiguration shiroFilterConfiguration() {
+        return shiroFilterConfiguration != null
+                ? shiroFilterConfiguration
+                : new ShiroFilterConfiguration();
+    }
+
     protected ShiroFilterFactoryBean shiroFilterFactoryBean() {
         ShiroFilterFactoryBean filterFactoryBean = new ShiroFilterFactoryBean();
 
@@ -64,6 +74,7 @@ public class AbstractShiroWebFilterConfiguration {
         filterFactoryBean.setUnauthorizedUrl(unauthorizedUrl);
 
         filterFactoryBean.setSecurityManager(securityManager);
+        filterFactoryBean.setShiroFilterConfiguration(shiroFilterConfiguration());
         filterFactoryBean.setGlobalFilters(globalFilters());
         filterFactoryBean.setFilterChainDefinitionMap(shiroFilterChainDefinition.getFilterChainMap());
 

--- a/web/src/main/java/org/apache/shiro/web/config/ShiroFilterConfiguration.java
+++ b/web/src/main/java/org/apache/shiro/web/config/ShiroFilterConfiguration.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.web.config;
+
+import org.apache.shiro.SecurityUtils;
+
+/**
+ * Configuration for Shiro's root level servlet filter.
+ *
+ * @since 1.10.0
+ */
+public class ShiroFilterConfiguration {
+
+    private boolean filterOncePerRequest = false;
+
+    private boolean staticSecurityManagerEnabled = false;
+
+    /**
+     * Returns {@code true} if the filter should only execute once per request. If set to {@code false} the filter
+     * will execute each time it is invoked.
+     * @return {@code true} if this filter should only execute once per request.
+     */
+    public boolean isFilterOncePerRequest() {
+        return filterOncePerRequest;
+    }
+
+    /**
+     * Sets whether the filter executes once per request or for every invocation of the filter. It is recommended
+     * to leave this disabled if you are using a {@link javax.servlet.RequestDispatcher RequestDispatcher} to forward
+     * or include request (JSP tags, programmatically, or via a framework).
+     *
+     * @param filterOncePerRequest Whether this filter executes once per request.
+     */
+    public void setFilterOncePerRequest(boolean filterOncePerRequest) {
+        this.filterOncePerRequest = filterOncePerRequest;
+    }
+
+    /**
+     * Returns {@code true} if the constructed {@link SecurityManager SecurityManager} associated with the filter
+     * should be bound to static memory (via
+     * {@code SecurityUtils.}{@link SecurityUtils#setSecurityManager(org.apache.shiro.mgt.SecurityManager) setSecurityManager}),
+     * {@code false} otherwise.
+     * <p/>
+     * The default value is {@code false}.
+     * <p/>
+     *
+     * @return {@code true} if the constructed {@link SecurityManager SecurityManager} associated with the filter should be bound
+     *         to static memory (via {@code SecurityUtils.}{@link SecurityUtils#setSecurityManager(org.apache.shiro.mgt.SecurityManager) setSecurityManager}),
+     *         {@code false} otherwise.
+     * @see <a href="https://issues.apache.org/jira/browse/SHIRO-287">SHIRO-287</a>
+     */
+    public boolean isStaticSecurityManagerEnabled() {
+        return staticSecurityManagerEnabled;
+    }
+
+    /**
+     * Sets if the constructed {@link SecurityManager SecurityManager} associated with the filter should be bound
+     * to static memory (via {@code SecurityUtils.}{@link SecurityUtils#setSecurityManager(org.apache.shiro.mgt.SecurityManager) setSecurityManager}).
+     * <p/>
+     * The default value is {@code false}.
+     *
+     * @param staticSecurityManagerEnabled if the constructed {@link SecurityManager SecurityManager} associated with the filter
+     *                                       should be bound to static memory (via
+     *                                       {@code SecurityUtils.}{@link SecurityUtils#setSecurityManager(org.apache.shiro.mgt.SecurityManager) setSecurityManager}).
+     * @see <a href="https://issues.apache.org/jira/browse/SHIRO-287">SHIRO-287</a>
+     */
+    public ShiroFilterConfiguration setStaticSecurityManagerEnabled(boolean staticSecurityManagerEnabled) {
+        this.staticSecurityManagerEnabled = staticSecurityManagerEnabled;
+        return this;
+    }
+}

--- a/web/src/main/java/org/apache/shiro/web/env/DefaultWebEnvironment.java
+++ b/web/src/main/java/org/apache/shiro/web/env/DefaultWebEnvironment.java
@@ -20,6 +20,7 @@ package org.apache.shiro.web.env;
 
 import org.apache.shiro.env.DefaultEnvironment;
 import org.apache.shiro.mgt.SecurityManager;
+import org.apache.shiro.web.config.ShiroFilterConfiguration;
 import org.apache.shiro.web.filter.mgt.FilterChainResolver;
 import org.apache.shiro.web.mgt.WebSecurityManager;
 
@@ -34,8 +35,11 @@ import java.util.Map;
 public class DefaultWebEnvironment extends DefaultEnvironment implements MutableWebEnvironment {
 
     private static final String DEFAULT_FILTER_CHAIN_RESOLVER_NAME = "filterChainResolver";
+    private static final String SHIRO_FILTER_CONFIG_NAME = "shiroFilter";
 
     private ServletContext servletContext;
+
+    private ShiroFilterConfiguration filterConfiguration;
 
     public DefaultWebEnvironment() {
         super();
@@ -83,5 +87,16 @@ public class DefaultWebEnvironment extends DefaultEnvironment implements Mutable
 
     public void setServletContext(ServletContext servletContext) {
         this.servletContext = servletContext;
+    }
+
+
+    @Override
+    public void setShiroFilterConfiguration(ShiroFilterConfiguration filterConfiguration) {
+        setObject(SHIRO_FILTER_CONFIG_NAME, filterConfiguration);
+    }
+
+    @Override
+    public ShiroFilterConfiguration getShiroFilterConfiguration() {
+        return getObject(SHIRO_FILTER_CONFIG_NAME, ShiroFilterConfiguration.class);
     }
 }

--- a/web/src/main/java/org/apache/shiro/web/env/IniWebEnvironment.java
+++ b/web/src/main/java/org/apache/shiro/web/env/IniWebEnvironment.java
@@ -28,6 +28,7 @@ import org.apache.shiro.lang.util.Initializable;
 import org.apache.shiro.lang.util.StringUtils;
 import org.apache.shiro.util.CollectionUtils;
 import org.apache.shiro.web.config.IniFilterChainResolverFactory;
+import org.apache.shiro.web.config.ShiroFilterConfiguration;
 import org.apache.shiro.web.config.WebIniSecurityManagerFactory;
 import org.apache.shiro.web.filter.mgt.FilterChainResolver;
 import org.apache.shiro.web.mgt.WebSecurityManager;
@@ -50,6 +51,7 @@ public class IniWebEnvironment extends ResourceBasedWebEnvironment implements In
 
     public static final String DEFAULT_WEB_INI_RESOURCE_PATH = "/WEB-INF/shiro.ini";
     public static final String FILTER_CHAIN_RESOLVER_NAME = "filterChainResolver";
+    public static final String SHIRO_FILTER_CONFIG_NAME = "shiroFilter";
 
     private static final Logger log = LoggerFactory.getLogger(IniWebEnvironment.class);
 
@@ -122,6 +124,9 @@ public class IniWebEnvironment extends ResourceBasedWebEnvironment implements In
 
         WebSecurityManager securityManager = createWebSecurityManager();
         setWebSecurityManager(securityManager);
+
+        ShiroFilterConfiguration filterConfiguration = createFilterConfiguration();
+        setShiroFilterConfiguration(filterConfiguration);
 
         FilterChainResolver resolver = createFilterChainResolver();
         if (resolver != null) {
@@ -254,6 +259,11 @@ public class IniWebEnvironment extends ResourceBasedWebEnvironment implements In
         }
 
         return ini;
+    }
+
+
+    protected ShiroFilterConfiguration createFilterConfiguration() {
+        return (ShiroFilterConfiguration) this.objects.get(SHIRO_FILTER_CONFIG_NAME);
     }
 
     protected FilterChainResolver createFilterChainResolver() {
@@ -397,6 +407,7 @@ public class IniWebEnvironment extends ResourceBasedWebEnvironment implements In
     protected Map<String, Object> getDefaults() {
         Map<String, Object> defaults = new HashMap<String, Object>();
         defaults.put(FILTER_CHAIN_RESOLVER_NAME, new IniFilterChainResolverFactory());
+        defaults.put(SHIRO_FILTER_CONFIG_NAME, new ShiroFilterConfiguration());
         return defaults;
     }
 

--- a/web/src/main/java/org/apache/shiro/web/env/MutableWebEnvironment.java
+++ b/web/src/main/java/org/apache/shiro/web/env/MutableWebEnvironment.java
@@ -18,6 +18,7 @@
  */
 package org.apache.shiro.web.env;
 
+import org.apache.shiro.web.config.ShiroFilterConfiguration;
 import org.apache.shiro.web.filter.mgt.FilterChainResolver;
 import org.apache.shiro.web.mgt.WebSecurityManager;
 
@@ -54,4 +55,11 @@ public interface MutableWebEnvironment extends WebEnvironment {
      * @param webSecurityManager the {@code WebEnvironment}'s {@link WebSecurityManager}.
      */
     void setWebSecurityManager(WebSecurityManager webSecurityManager);
+
+    /**
+     * Sets the {@code WebEnvironment}'s {@link ShiroFilterConfiguration}.
+     *
+     * @param filterConfiguration the {@code WebEnvironment}'s {@link ShiroFilterConfiguration}.
+     */
+    void setShiroFilterConfiguration(ShiroFilterConfiguration filterConfiguration);
 }

--- a/web/src/main/java/org/apache/shiro/web/env/WebEnvironment.java
+++ b/web/src/main/java/org/apache/shiro/web/env/WebEnvironment.java
@@ -19,6 +19,7 @@
 package org.apache.shiro.web.env;
 
 import org.apache.shiro.env.Environment;
+import org.apache.shiro.web.config.ShiroFilterConfiguration;
 import org.apache.shiro.web.filter.mgt.FilterChainResolver;
 import org.apache.shiro.web.mgt.WebSecurityManager;
 
@@ -54,4 +55,14 @@ public interface WebEnvironment extends Environment {
      * @return the web application's security manager instance.
      */
     WebSecurityManager getWebSecurityManager();
+
+
+    /**
+     * Returns the configuration object used to configure the ShiroFilter.
+     *
+     * @return the configuration object used to configure the ShiroFilter.
+     */
+    default ShiroFilterConfiguration getShiroFilterConfiguration() {
+        return new ShiroFilterConfiguration();
+    }
 }

--- a/web/src/main/java/org/apache/shiro/web/servlet/AbstractShiroFilter.java
+++ b/web/src/main/java/org/apache/shiro/web/servlet/AbstractShiroFilter.java
@@ -22,6 +22,7 @@ import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.session.Session;
 import org.apache.shiro.subject.ExecutionException;
 import org.apache.shiro.subject.Subject;
+import org.apache.shiro.web.config.ShiroFilterConfiguration;
 import org.apache.shiro.web.filter.mgt.FilterChainResolver;
 import org.apache.shiro.web.mgt.DefaultWebSecurityManager;
 import org.apache.shiro.web.mgt.WebSecurityManager;
@@ -108,6 +109,13 @@ public abstract class AbstractShiroFilter extends OncePerRequestFilter {
 
     public void setFilterChainResolver(FilterChainResolver filterChainResolver) {
         this.filterChainResolver = filterChainResolver;
+    }
+
+    public void setShiroFilterConfiguration(ShiroFilterConfiguration config) {
+        this.setFilterOncePerRequest(config.isFilterOncePerRequest());
+
+        // this property could have already been set with a servlet config param
+        this.setStaticSecurityManagerEnabled(config.isStaticSecurityManagerEnabled() || isStaticSecurityManagerEnabled());
     }
 
     /**

--- a/web/src/main/java/org/apache/shiro/web/servlet/OncePerRequestFilter.java
+++ b/web/src/main/java/org/apache/shiro/web/servlet/OncePerRequestFilter.java
@@ -66,6 +66,13 @@ public abstract class OncePerRequestFilter extends NameableFilter {
     private boolean enabled = true; //most filters wish to execute when configured, so default to true
 
     /**
+     * Determines if the filter's once per request functionality is enabled, defaults to false. It is recommended
+     * to leave this disabled if you are using a {@link javax.servlet.RequestDispatcher RequestDispatcher} to forward
+     * or include request (JSP tags, programmatically, or via a framework).
+     */
+    private boolean filterOncePerRequest = false;
+
+    /**
      * Returns {@code true} if this filter should <em>generally</em><b>*</b> execute for any request,
      * {@code false} if it should let the request/response pass through immediately to the next
      * element in the {@link FilterChain}.  The default value is {@code true}, as most filters would inherently need
@@ -96,6 +103,28 @@ public abstract class OncePerRequestFilter extends NameableFilter {
     }
 
     /**
+     * Returns {@code true} if this filter should only execute once per request. If set to {@code false} this filter
+     * will execute each time it is invoked.
+     * @return {@code true} if this filter should only execute once per request.
+     * @since 1.10
+     */
+    public boolean isFilterOncePerRequest() {
+        return filterOncePerRequest;
+    }
+
+    /**
+     * Sets whether this filter executes once per request or for every invocation of the filter. It is recommended
+     * to leave this disabled if you are using a {@link javax.servlet.RequestDispatcher RequestDispatcher} to forward
+     * or include request (JSP tags, programmatically, or via a framework). 
+     *
+     * @param filterOncePerRequest Whether this filter executes once per request.
+     * @since 1.10
+     */
+    public void setFilterOncePerRequest(boolean filterOncePerRequest) {
+        this.filterOncePerRequest = filterOncePerRequest;
+    }
+
+    /**
      * This {@code doFilter} implementation stores a request attribute for
      * "already filtered", proceeding without filtering again if the
      * attribute is already there.
@@ -107,7 +136,7 @@ public abstract class OncePerRequestFilter extends NameableFilter {
     public final void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
         String alreadyFilteredAttributeName = getAlreadyFilteredAttributeName();
-        if ( request.getAttribute(alreadyFilteredAttributeName) != null ) {
+        if ( request.getAttribute(alreadyFilteredAttributeName) != null && filterOncePerRequest) {
             log.trace("Filter '{}' already executed.  Proceeding without invoking this filter.", getName());
             filterChain.doFilter(request, response);
         } else //noinspection deprecation

--- a/web/src/main/java/org/apache/shiro/web/servlet/ShiroFilter.java
+++ b/web/src/main/java/org/apache/shiro/web/servlet/ShiroFilter.java
@@ -70,8 +70,10 @@ public class ShiroFilter extends AbstractShiroFilter {
      */
     @Override
     public void init() throws Exception {
+
         WebEnvironment env = WebUtils.getRequiredWebEnvironment(getServletContext());
 
+        setShiroFilterConfiguration(env.getShiroFilterConfiguration());
         setSecurityManager(env.getWebSecurityManager());
 
         FilterChainResolver resolver = env.getFilterChainResolver();

--- a/web/src/test/groovy/org/apache/shiro/web/env/IniWebEnvironmentTest.groovy
+++ b/web/src/test/groovy/org/apache/shiro/web/env/IniWebEnvironmentTest.groovy
@@ -52,8 +52,8 @@ class IniWebEnvironmentTest {
         env.init()
 
         assertNotNull env.objects
-        //asserts that the objects size = securityManager (1) + the event bus (1) + filterChainResolverFactory (1) + num custom objects + num default filters
-        def expectedSize = 4 + DefaultFilter.values().length
+        //asserts that the objects size = securityManager (1) + the event bus (1) + filterChainResolverFactory (1) + filterConfig (1) + num custom objects + num default filters
+        def expectedSize = 5 + DefaultFilter.values().length
         assertEquals expectedSize, env.objects.size()
         assertNotNull env.objects['securityManager']
         assertNotNull env.objects['compositeBean']
@@ -84,10 +84,11 @@ class IniWebEnvironmentTest {
         env.init()
 
         assertNotNull env.objects
-        //asserts that the objects size = securityManager (1) + the event bus (1) + filterChainResolverFactory (1) + num custom objects + num default filters
-        def expectedSize = 5 + DefaultFilter.values().length
+        //asserts that the objects size = securityManager (1) + the event bus (1) + filterChainResolverFactory (1) + shiroFilter (1) + num custom objects + num default filters
+        def expectedSize = 6 + DefaultFilter.values().length
         assertEquals expectedSize, env.objects.size()
         assertNotNull env.objects['securityManager']
+        assertNotNull env.objects['shiroFilter']
 
         def compositeBean = (CompositeBean) env.objects['compositeBean']
         def simpleBean = (SimpleBean) env.objects['simpleBean']

--- a/web/src/test/groovy/org/apache/shiro/web/env/MockWebEnvironment.groovy
+++ b/web/src/test/groovy/org/apache/shiro/web/env/MockWebEnvironment.groovy
@@ -19,6 +19,7 @@
 package org.apache.shiro.web.env
 
 import org.apache.shiro.mgt.SecurityManager
+import org.apache.shiro.web.config.ShiroFilterConfiguration
 import org.apache.shiro.web.filter.mgt.FilterChainResolver
 import org.apache.shiro.web.mgt.WebSecurityManager
 
@@ -41,6 +42,11 @@ class MockWebEnvironment implements MutableWebEnvironment {
 
     @Override
     void setWebSecurityManager(WebSecurityManager webSecurityManager) {
+
+    }
+
+    @Override
+    void setShiroFilterConfiguration(ShiroFilterConfiguration filterConfiguration) {
 
     }
 

--- a/web/src/test/groovy/org/apache/shiro/web/servlet/ShiroFilterTest.groovy
+++ b/web/src/test/groovy/org/apache/shiro/web/servlet/ShiroFilterTest.groovy
@@ -18,6 +18,8 @@
  */
 package org.apache.shiro.web.servlet
 
+import org.apache.shiro.web.config.ShiroFilterConfiguration
+
 import javax.servlet.FilterConfig
 import javax.servlet.ServletContext
 import org.apache.shiro.web.env.EnvironmentLoader
@@ -39,6 +41,7 @@ class ShiroFilterTest {
 
         def filterConfig = createStrictMock(FilterConfig)
         def servletContext = createStrictMock(ServletContext)
+        def shiroFilterConfig = createStrictMock(ShiroFilterConfiguration)
         def webEnvironment = createStrictMock(WebEnvironment)
         def webSecurityManager = createStrictMock(WebSecurityManager)
         def filterChainResolver = createStrictMock(FilterChainResolver)
@@ -46,10 +49,13 @@ class ShiroFilterTest {
         expect(filterConfig.servletContext).andReturn(servletContext).anyTimes()
         expect(filterConfig.getInitParameter(eq(AbstractShiroFilter.STATIC_INIT_PARAM_NAME))).andReturn null
         expect(servletContext.getAttribute(eq(EnvironmentLoader.ENVIRONMENT_ATTRIBUTE_KEY))).andReturn webEnvironment
+        expect(shiroFilterConfig.filterOncePerRequest).andReturn true
+        expect(shiroFilterConfig.staticSecurityManagerEnabled).andReturn false
+        expect(webEnvironment.shiroFilterConfiguration).andReturn shiroFilterConfig
         expect(webEnvironment.webSecurityManager).andReturn webSecurityManager
         expect(webEnvironment.filterChainResolver).andReturn filterChainResolver
 
-        replay filterConfig, servletContext, webEnvironment, webSecurityManager, filterChainResolver
+        replay filterConfig, servletContext, webEnvironment, webSecurityManager, filterChainResolver, shiroFilterConfig
 
         ShiroFilter filter = new ShiroFilter()
 
@@ -57,9 +63,67 @@ class ShiroFilterTest {
 
         assertSame filter.securityManager, webSecurityManager
         assertSame filter.filterChainResolver, filterChainResolver
+        assertTrue(filter.isFilterOncePerRequest())
+        assertFalse(filter.isStaticSecurityManagerEnabled())
 
-        verify filterConfig, servletContext, webEnvironment, webSecurityManager, filterChainResolver
-
+        verify filterConfig, servletContext, webEnvironment, webSecurityManager, filterChainResolver, shiroFilterConfig
     }
 
+    @Test
+    void configStaticSecManager_initParm() {
+
+        def filterConfig = createStrictMock(FilterConfig)
+        def servletContext = createStrictMock(ServletContext)
+        def shiroFilterConfig = createStrictMock(ShiroFilterConfiguration)
+        def webEnvironment = createStrictMock(WebEnvironment)
+        def webSecurityManager = createStrictMock(WebSecurityManager)
+        def filterChainResolver = createStrictMock(FilterChainResolver)
+
+        expect(filterConfig.servletContext).andReturn(servletContext).anyTimes()
+        expect(filterConfig.getInitParameter(eq(AbstractShiroFilter.STATIC_INIT_PARAM_NAME))).andReturn "true"
+        expect(servletContext.getAttribute(eq(EnvironmentLoader.ENVIRONMENT_ATTRIBUTE_KEY))).andReturn webEnvironment
+        expect(shiroFilterConfig.filterOncePerRequest).andReturn false
+        expect(shiroFilterConfig.staticSecurityManagerEnabled).andReturn false
+        expect(webEnvironment.shiroFilterConfiguration).andReturn shiroFilterConfig
+        expect(webEnvironment.webSecurityManager).andReturn webSecurityManager
+        expect(webEnvironment.filterChainResolver).andReturn filterChainResolver
+
+        replay filterConfig, servletContext, webEnvironment, webSecurityManager, filterChainResolver, shiroFilterConfig
+
+        ShiroFilter filter = new ShiroFilter()
+
+        filter.init(filterConfig)
+
+        assertTrue(filter.isStaticSecurityManagerEnabled())
+        verify filterConfig, servletContext, webEnvironment, webSecurityManager, filterChainResolver, shiroFilterConfig
+    }
+
+    @Test
+    void configStaticSecManager_config() {
+
+        def filterConfig = createStrictMock(FilterConfig)
+        def servletContext = createStrictMock(ServletContext)
+        def shiroFilterConfig = createStrictMock(ShiroFilterConfiguration)
+        def webEnvironment = createStrictMock(WebEnvironment)
+        def webSecurityManager = createStrictMock(WebSecurityManager)
+        def filterChainResolver = createStrictMock(FilterChainResolver)
+
+        expect(filterConfig.servletContext).andReturn(servletContext).anyTimes()
+        expect(filterConfig.getInitParameter(eq(AbstractShiroFilter.STATIC_INIT_PARAM_NAME))).andReturn null
+        expect(servletContext.getAttribute(eq(EnvironmentLoader.ENVIRONMENT_ATTRIBUTE_KEY))).andReturn webEnvironment
+        expect(shiroFilterConfig.filterOncePerRequest).andReturn false
+        expect(shiroFilterConfig.staticSecurityManagerEnabled).andReturn true
+        expect(webEnvironment.shiroFilterConfiguration).andReturn shiroFilterConfig
+        expect(webEnvironment.webSecurityManager).andReturn webSecurityManager
+        expect(webEnvironment.filterChainResolver).andReturn filterChainResolver
+
+        replay filterConfig, servletContext, webEnvironment, webSecurityManager, filterChainResolver, shiroFilterConfig
+
+        ShiroFilter filter = new ShiroFilter()
+
+        filter.init(filterConfig)
+
+        assertTrue(filter.isStaticSecurityManagerEnabled())
+        verify filterConfig, servletContext, webEnvironment, webSecurityManager, filterChainResolver, shiroFilterConfig
+    }
 }

--- a/web/src/test/groovy/org/apache/shiro/web/servlet/ShiroFilterTest.groovy
+++ b/web/src/test/groovy/org/apache/shiro/web/servlet/ShiroFilterTest.groovy
@@ -19,17 +19,20 @@
 package org.apache.shiro.web.servlet
 
 import org.apache.shiro.web.config.ShiroFilterConfiguration
-
-import javax.servlet.FilterConfig
-import javax.servlet.ServletContext
 import org.apache.shiro.web.env.EnvironmentLoader
 import org.apache.shiro.web.env.WebEnvironment
 import org.apache.shiro.web.filter.mgt.FilterChainResolver
 import org.apache.shiro.web.mgt.WebSecurityManager
 import org.junit.Test
 
-import static org.easymock.EasyMock.*
-import static org.junit.Assert.*
+import javax.servlet.FilterConfig
+import javax.servlet.ServletContext
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.sameInstance
+import static org.mockito.ArgumentMatchers.eq
+import static org.mockito.Mockito.mock
+import static org.mockito.Mockito.when
 
 /**
  * Unit tests for {@link ShiroFilter}.
@@ -39,91 +42,81 @@ class ShiroFilterTest {
     @Test
     void testInit() {
 
-        def filterConfig = createStrictMock(FilterConfig)
-        def servletContext = createStrictMock(ServletContext)
-        def shiroFilterConfig = createStrictMock(ShiroFilterConfiguration)
-        def webEnvironment = createStrictMock(WebEnvironment)
-        def webSecurityManager = createStrictMock(WebSecurityManager)
-        def filterChainResolver = createStrictMock(FilterChainResolver)
+        def filterConfig = mock(FilterConfig)
+        def servletContext = mock(ServletContext)
+        def shiroFilterConfig = mock(ShiroFilterConfiguration)
+        def webEnvironment = mock(WebEnvironment)
+        def webSecurityManager = mock(WebSecurityManager)
+        def filterChainResolver = mock(FilterChainResolver)
 
-        expect(filterConfig.servletContext).andReturn(servletContext).anyTimes()
-        expect(filterConfig.getInitParameter(eq(AbstractShiroFilter.STATIC_INIT_PARAM_NAME))).andReturn null
-        expect(servletContext.getAttribute(eq(EnvironmentLoader.ENVIRONMENT_ATTRIBUTE_KEY))).andReturn webEnvironment
-        expect(shiroFilterConfig.filterOncePerRequest).andReturn true
-        expect(shiroFilterConfig.staticSecurityManagerEnabled).andReturn false
-        expect(webEnvironment.shiroFilterConfiguration).andReturn shiroFilterConfig
-        expect(webEnvironment.webSecurityManager).andReturn webSecurityManager
-        expect(webEnvironment.filterChainResolver).andReturn filterChainResolver
-
-        replay filterConfig, servletContext, webEnvironment, webSecurityManager, filterChainResolver, shiroFilterConfig
+        when(filterConfig.servletContext).thenReturn(servletContext)
+        when(filterConfig.getInitParameter(eq(AbstractShiroFilter.STATIC_INIT_PARAM_NAME))).thenReturn null
+        when(servletContext.getAttribute(eq(EnvironmentLoader.ENVIRONMENT_ATTRIBUTE_KEY))).thenReturn webEnvironment
+        when(shiroFilterConfig.filterOncePerRequest).thenReturn true
+        when(shiroFilterConfig.staticSecurityManagerEnabled).thenReturn false
+        when(webEnvironment.shiroFilterConfiguration).thenReturn shiroFilterConfig
+        when(webEnvironment.webSecurityManager).thenReturn webSecurityManager
+        when(webEnvironment.filterChainResolver).thenReturn filterChainResolver
 
         ShiroFilter filter = new ShiroFilter()
 
         filter.init(filterConfig)
 
-        assertSame filter.securityManager, webSecurityManager
-        assertSame filter.filterChainResolver, filterChainResolver
-        assertTrue(filter.isFilterOncePerRequest())
-        assertFalse(filter.isStaticSecurityManagerEnabled())
-
-        verify filterConfig, servletContext, webEnvironment, webSecurityManager, filterChainResolver, shiroFilterConfig
+        assertThat filter.securityManager, sameInstance(webSecurityManager)
+        assertThat filter.filterChainResolver, sameInstance(filterChainResolver)
+        assertThat("expected filter.isFilterOncePerRequest() to return true", filter.isFilterOncePerRequest())
+        assertThat("expected filter.isStaticSecurityManagerEnabled() to return false", !filter.isStaticSecurityManagerEnabled())
     }
 
     @Test
     void configStaticSecManager_initParm() {
 
-        def filterConfig = createStrictMock(FilterConfig)
-        def servletContext = createStrictMock(ServletContext)
-        def shiroFilterConfig = createStrictMock(ShiroFilterConfiguration)
-        def webEnvironment = createStrictMock(WebEnvironment)
-        def webSecurityManager = createStrictMock(WebSecurityManager)
-        def filterChainResolver = createStrictMock(FilterChainResolver)
+        def filterConfig = mock(FilterConfig)
+        def servletContext = mock(ServletContext)
+        def shiroFilterConfig = mock(ShiroFilterConfiguration)
+        def webEnvironment = mock(WebEnvironment)
+        def webSecurityManager = mock(WebSecurityManager)
+        def filterChainResolver = mock(FilterChainResolver)
 
-        expect(filterConfig.servletContext).andReturn(servletContext).anyTimes()
-        expect(filterConfig.getInitParameter(eq(AbstractShiroFilter.STATIC_INIT_PARAM_NAME))).andReturn "true"
-        expect(servletContext.getAttribute(eq(EnvironmentLoader.ENVIRONMENT_ATTRIBUTE_KEY))).andReturn webEnvironment
-        expect(shiroFilterConfig.filterOncePerRequest).andReturn false
-        expect(shiroFilterConfig.staticSecurityManagerEnabled).andReturn false
-        expect(webEnvironment.shiroFilterConfiguration).andReturn shiroFilterConfig
-        expect(webEnvironment.webSecurityManager).andReturn webSecurityManager
-        expect(webEnvironment.filterChainResolver).andReturn filterChainResolver
-
-        replay filterConfig, servletContext, webEnvironment, webSecurityManager, filterChainResolver, shiroFilterConfig
+        when(filterConfig.servletContext).thenReturn(servletContext)
+        when(filterConfig.getInitParameter(eq(AbstractShiroFilter.STATIC_INIT_PARAM_NAME))).thenReturn "true"
+        when(servletContext.getAttribute(eq(EnvironmentLoader.ENVIRONMENT_ATTRIBUTE_KEY))).thenReturn webEnvironment
+        when(shiroFilterConfig.filterOncePerRequest).thenReturn false
+        when(shiroFilterConfig.staticSecurityManagerEnabled).thenReturn false
+        when(webEnvironment.shiroFilterConfiguration).thenReturn shiroFilterConfig
+        when(webEnvironment.webSecurityManager).thenReturn webSecurityManager
+        when(webEnvironment.filterChainResolver).thenReturn filterChainResolver
 
         ShiroFilter filter = new ShiroFilter()
 
         filter.init(filterConfig)
 
-        assertTrue(filter.isStaticSecurityManagerEnabled())
-        verify filterConfig, servletContext, webEnvironment, webSecurityManager, filterChainResolver, shiroFilterConfig
+        assertThat("expected filter.isStaticSecurityManagerEnabled() to return true", filter.isStaticSecurityManagerEnabled())
     }
 
     @Test
     void configStaticSecManager_config() {
 
-        def filterConfig = createStrictMock(FilterConfig)
-        def servletContext = createStrictMock(ServletContext)
-        def shiroFilterConfig = createStrictMock(ShiroFilterConfiguration)
-        def webEnvironment = createStrictMock(WebEnvironment)
-        def webSecurityManager = createStrictMock(WebSecurityManager)
-        def filterChainResolver = createStrictMock(FilterChainResolver)
+        def filterConfig = mock(FilterConfig)
+        def servletContext = mock(ServletContext)
+        def shiroFilterConfig = mock(ShiroFilterConfiguration)
+        def webEnvironment = mock(WebEnvironment)
+        def webSecurityManager = mock(WebSecurityManager)
+        def filterChainResolver = mock(FilterChainResolver)
 
-        expect(filterConfig.servletContext).andReturn(servletContext).anyTimes()
-        expect(filterConfig.getInitParameter(eq(AbstractShiroFilter.STATIC_INIT_PARAM_NAME))).andReturn null
-        expect(servletContext.getAttribute(eq(EnvironmentLoader.ENVIRONMENT_ATTRIBUTE_KEY))).andReturn webEnvironment
-        expect(shiroFilterConfig.filterOncePerRequest).andReturn false
-        expect(shiroFilterConfig.staticSecurityManagerEnabled).andReturn true
-        expect(webEnvironment.shiroFilterConfiguration).andReturn shiroFilterConfig
-        expect(webEnvironment.webSecurityManager).andReturn webSecurityManager
-        expect(webEnvironment.filterChainResolver).andReturn filterChainResolver
-
-        replay filterConfig, servletContext, webEnvironment, webSecurityManager, filterChainResolver, shiroFilterConfig
+        when(filterConfig.servletContext).thenReturn(servletContext)
+        when(filterConfig.getInitParameter(eq(AbstractShiroFilter.STATIC_INIT_PARAM_NAME))).thenReturn null
+        when(servletContext.getAttribute(eq(EnvironmentLoader.ENVIRONMENT_ATTRIBUTE_KEY))).thenReturn webEnvironment
+        when(shiroFilterConfig.filterOncePerRequest).thenReturn false
+        when(shiroFilterConfig.staticSecurityManagerEnabled).thenReturn true
+        when(webEnvironment.shiroFilterConfiguration).thenReturn shiroFilterConfig
+        when(webEnvironment.webSecurityManager).thenReturn webSecurityManager
+        when(webEnvironment.filterChainResolver).thenReturn filterChainResolver
 
         ShiroFilter filter = new ShiroFilter()
 
         filter.init(filterConfig)
 
-        assertTrue(filter.isStaticSecurityManagerEnabled())
-        verify filterConfig, servletContext, webEnvironment, webSecurityManager, filterChainResolver, shiroFilterConfig
+        assertThat("expected filter.isStaticSecurityManagerEnabled() to return true", filter.isStaticSecurityManagerEnabled())
     }
 }

--- a/web/src/test/java/org/apache/shiro/web/env/WebEnvironmentStub.java
+++ b/web/src/test/java/org/apache/shiro/web/env/WebEnvironmentStub.java
@@ -19,6 +19,7 @@
 package org.apache.shiro.web.env;
 
 import org.apache.shiro.mgt.SecurityManager;
+import org.apache.shiro.web.config.ShiroFilterConfiguration;
 import org.apache.shiro.web.filter.mgt.FilterChainResolver;
 import org.apache.shiro.web.mgt.WebSecurityManager;
 
@@ -31,6 +32,8 @@ public class WebEnvironmentStub implements WebEnvironment, MutableWebEnvironment
     private WebSecurityManager webSecurityManager;
 
     private ServletContext servletContext;
+
+    private ShiroFilterConfiguration filterConfiguration;
 
 
     @Override
@@ -66,5 +69,15 @@ public class WebEnvironmentStub implements WebEnvironment, MutableWebEnvironment
     @Override
     public SecurityManager getSecurityManager() {
         return getWebSecurityManager();
+    }
+
+    @Override
+    public void setShiroFilterConfiguration(ShiroFilterConfiguration filterConfiguration) {
+        this.filterConfiguration = filterConfiguration;
+    }
+
+    @Override
+    public ShiroFilterConfiguration getShiroFilterConfiguration() {
+        return filterConfiguration;
     }
 }

--- a/web/src/test/java/org/apache/shiro/web/servlet/OncePerRequestFilterTest.java
+++ b/web/src/test/java/org/apache/shiro/web/servlet/OncePerRequestFilterTest.java
@@ -27,8 +27,9 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import java.io.IOException;
 
-import static org.easymock.EasyMock.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for the {@link OncePerRequestFilter} implementation.
@@ -48,9 +49,9 @@ public class OncePerRequestFilterTest {
     @Before
     public void setUp() {
         filter = createTestInstance();
-        chain = createNiceMock(FilterChain.class);
-        request = createNiceMock(ServletRequest.class);
-        response = createNiceMock(ServletResponse.class);
+        chain = mock(FilterChain.class);
+        request = mock(ServletRequest.class);
+        response = mock(ServletResponse.class);
     }
 
     private CountingOncePerRequestFilter createTestInstance() {
@@ -63,12 +64,10 @@ public class OncePerRequestFilterTest {
     @SuppressWarnings({"JavaDoc"})
     @Test
     public void testEnabled() throws IOException, ServletException {
-        expect(request.getAttribute(ATTR_NAME)).andReturn(null).anyTimes();
-        replay(request);
+        when(request.getAttribute(ATTR_NAME)).thenReturn(null);
 
         filter.doFilter(request, response, chain);
 
-        verify(request);
         assertEquals("Filter should have executed", 1, filter.filterCount);
     }
 
@@ -80,12 +79,10 @@ public class OncePerRequestFilterTest {
     public void testDisabled() throws IOException, ServletException {
         filter.setEnabled(false); //test disabled
 
-        expect(request.getAttribute(ATTR_NAME)).andReturn(null).anyTimes();
-        replay(request);
+        when(request.getAttribute(ATTR_NAME)).thenReturn(null);
 
         filter.doFilter(request, response, chain);
 
-        verify(request);
         assertEquals("Filter should NOT have executed", 0, filter.filterCount);
     }
 
@@ -93,13 +90,11 @@ public class OncePerRequestFilterTest {
     public void testFilterOncePerRequest() throws IOException, ServletException {
         filter.setFilterOncePerRequest(false);
 
-        expect(request.getAttribute(ATTR_NAME)).andReturn(null).andReturn(true);
-        replay(request);
+        when(request.getAttribute(ATTR_NAME)).thenReturn(null, true);
 
         filter.doFilter(request, response, chain);
         filter.doFilter(request, response, chain);
 
-        verify(request);
         assertEquals("Filter should have executed twice", 2, filter.filterCount);
     }
 
@@ -116,5 +111,4 @@ public class OncePerRequestFilterTest {
             filterCount++;
         }
     }
-
 }


### PR DESCRIPTION
Adds new ShiroFilterConfiguration class exposed through the WebEnvironment
This class allows for confiuration of the Shiro filter through various config mechanisms (Ini, Guice, Spring, etc)
This makes it easer to enable a static security manager when using Shiro's Servlet fragment, as now a web.xml is not required

Backport: 28e10e0ca1cdcd2cede86802fde8464b29265fc8

