### PR TITLE
[SHIRO-899] Added a shim for deprecated javax.servlet.http.HttpSessionContext class as it …

### DIFF
--- a/web/src/main/java/jakarta/servlet/http/HttpSessionContext.java
+++ b/web/src/main/java/jakarta/servlet/http/HttpSessionContext.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package jakarta.servlet.http;
+
+/**
+ * Shim for class that no longer exists in Jakarta EE,
+ * but still exists in Java EE
+ *
+ * @author lprimak
+ */
+@Deprecated
+public interface HttpSessionContext {
+
+}


### PR DESCRIPTION
…was causing issues with Jakarta EE 10 in native session tests

This change was necessary for compatibility for both Servlet 3.x and 5.x+
Since deprecated interface `HttpSessionContext` was removed in Servlet 5.x, the shim needs to be back in place
for the same code to compile and run on both servlet versions in the shaded Jakarta artifacts.

Tests that failed will be introduced in the upcoming EE integration tests

<!--
For Security Vulnerabilities, please email: security@shiro.apache.org
For more details on how to report a vulnerablity see: https://www.apache.org/security/
-->

Following this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SHIRO) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SHIRO-XXX] - Fixes bug in SessionManager`,
       where you replace `SHIRO-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install apache-rat:check` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If you have a group of commits related to the same change, please squash your commits into one and force push your branch using `git rebase -i`. 
 
 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

```
----- Root Cause -----
java.lang.NoClassDefFoundError: jakarta/servlet/http/HttpSessionContext
	at org.apache.shiro.web.servlet.ShiroHttpServletRequest.getSession(ShiroHttpServletRequest.java:159)
	at com.sun.faces.context.ExternalContextImpl.getSession(ExternalContextImpl.java:143)
	at jakarta.faces.context.ExternalContextWrapper.getSession(ExternalContextWrapper.java:483)
	at jakarta.faces.context.ExternalContextWrapper.getSession(ExternalContextWrapper.java:483)
	at com.sun.faces.application.view.FaceletViewHandlingStrategy.getSession(FaceletViewHandlingStrategy.java:1865)
	at com.sun.faces.application.view.FaceletViewHandlingStrategy.renderView(FaceletViewHandlingStrategy.java:405)
	at com.sun.faces.application.view.MultiViewHandler.renderView(MultiViewHandler.java:162)
	at jakarta.faces.application.ViewHandlerWrapper.renderView(ViewHandlerWrapper.java:125)
	at jakarta.faces.application.ViewHandlerWrapper.renderView(ViewHandlerWrapper.java:125)
	at org.omnifaces.viewhandler.OmniViewHandler.renderView(OmniViewHandler.java:151)
	at jakarta.faces.application.ViewHandlerWrapper.renderView(ViewHandlerWrapper.java:125)
	at com.sun.faces.lifecycle.RenderResponsePhase.execute(RenderResponsePhase.java:93)
	at com.sun.faces.lifecycle.Phase.doPhase(Phase.java:72)
	at com.sun.faces.lifecycle.LifecycleImpl.render(LifecycleImpl.java:178)
	at jakarta.faces.webapp.FacesServlet.executeLifecyle(FacesServlet.java:692)
	at jakarta.faces.webapp.FacesServlet.service(FacesServlet.java:449)
	at org.apache.catalina.core.StandardWrapper.service(StandardWrapper.java:1569)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:331)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:211)
	at org.apache.shiro.web.servlet.ProxiedFilterChain.doFilter(ProxiedFilterChain.java:61)
	at org.apache.shiro.web.servlet.AdviceFilter.executeChain(AdviceFilter.java:108)
	at org.apache.shiro.web.servlet.AdviceFilter.doFilterInternal(AdviceFilter.java:137)
	at org.apache.shiro.web.servlet.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:154)
	at org.apache.shiro.web.servlet.ProxiedFilterChain.doFilter(ProxiedFilterChain.java:66)
	at org.apache.shiro.web.servlet.AdviceFilter.executeChain(AdviceFilter.java:108)
	at org.apache.shiro.web.servlet.AdviceFilter.doFilterInternal(AdviceFilter.java:137)
	at org.apache.shiro.web.servlet.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:154)
	at org.apache.shiro.web.servlet.ProxiedFilterChain.doFilter(ProxiedFilterChain.java:66)
	at org.apache.shiro.web.servlet.AbstractShiroFilter.executeChain(AbstractShiroFilter.java:458)
	at com.flowlogix.shiro.ee.filters.ShiroFilter.executeChain(ShiroFilter.java:239)
	at org.apache.shiro.web.servlet.AbstractShiroFilter$1.call(AbstractShiroFilter.java:373)
	at org.apache.shiro.subject.support.SubjectCallable.doCall(SubjectCallable.java:90)
	at org.apache.shiro.subject.support.SubjectCallable.call(SubjectCallable.java:83)
	at org.apache.shiro.subject.support.DelegatingSubject.execute(DelegatingSubject.java:388)
	at org.apache.shiro.web.servlet.AbstractShiroFilter.doFilterInternal(AbstractShiroFilter.java:370)
	at org.apache.shiro.web.servlet.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:154)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:253)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:211)
	at org.apache.catalina.core.ApplicationDispatcher.doInvoke(ApplicationDispatcher.java:816)
	at org.apache.catalina.core.ApplicationDispatcher.invoke(ApplicationDispatcher.java:683)
	at org.apache.catalina.core.ApplicationDispatcher.processRequest(ApplicationDispatcher.java:527)
	at org.apache.catalina.core.ApplicationDispatcher.doDispatch(ApplicationDispatcher.java:497)
	at org.apache.catalina.core.ApplicationDispatcher.dispatch(ApplicationDispatcher.java:379)
	at org.apache.catalina.core.StandardHostValve.custom(StandardHostValve.java:504)
	at org.apache.catalina.core.StandardHostValve.dispatchToErrorPage(StandardHostValve.java:693)
	at org.apache.catalina.core.StandardHostValve.status(StandardHostValve.java:384)
	at org.apache.catalina.core.StandardHostValve.throwable(StandardHostValve.java:318)
	at org.apache.catalina.core.StandardHostValve.postInvoke(StandardHostValve.java:216)
	at org.apache.catalina.connector.CoyoteAdapter.doService(CoyoteAdapter.java:379)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:239)
	at com.sun.enterprise.v3.services.impl.ContainerMapper$HttpHandlerCallable.call(ContainerMapper.java:520)
	at com.sun.enterprise.v3.services.impl.ContainerMapper.service(ContainerMapper.java:217)
	at org.glassfish.grizzly.http.server.HttpHandler.runService(HttpHandler.java:174)
	at org.glassfish.grizzly.http.server.HttpHandler.doHandle(HttpHandler.java:153)
	at org.glassfish.grizzly.http.server.HttpServerFilter.handleRead(HttpServerFilter.java:196)
	at org.glassfish.grizzly.filterchain.ExecutorResolver$9.execute(ExecutorResolver.java:88)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeFilter(DefaultFilterChain.java:246)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeChainPart(DefaultFilterChain.java:178)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.execute(DefaultFilterChain.java:118)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.process(DefaultFilterChain.java:96)
	at org.glassfish.grizzly.ProcessorExecutor.execute(ProcessorExecutor.java:51)
	at org.glassfish.grizzly.nio.transport.TCPNIOTransport.fireIOEvent(TCPNIOTransport.java:510)
	at org.glassfish.grizzly.strategies.AbstractIOStrategy.fireIOEvent(AbstractIOStrategy.java:82)
	at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy.run0(WorkerThreadIOStrategy.java:83)
	at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy$WorkerThreadRunnable.run(WorkerThreadIOStrategy.java:101)
	at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.doWork(AbstractThreadPool.java:535)
	at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.run(AbstractThreadPool.java:515)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.ClassNotFoundException: jakarta.servlet.http.HttpSessionContext
	at org.glassfish.web.loader.WebappClassLoader.loadClass(WebappClassLoader.java:1843)
	at org.glassfish.web.loader.WebappClassLoader.loadClass(WebappClassLoader.java:1684)
	... 68 more
]]
```
