### PR TITLE
Restrict classes loaded in ClassResolvingObjectInputStream to org.apa…

### DIFF
--- a/lang/src/main/java/org/apache/shiro/lang/io/ClassResolvingObjectInputStream.java
+++ b/lang/src/main/java/org/apache/shiro/lang/io/ClassResolvingObjectInputStream.java
@@ -50,6 +50,9 @@ public class ClassResolvingObjectInputStream extends ObjectInputStream {
     @Override
     protected Class<?> resolveClass(ObjectStreamClass osc) throws IOException, ClassNotFoundException {
         try {
+            if (!(osc.getName().startsWith("org.apache.shiro") || osc.getName().startsWith("java.util"))) {
+                throw new ClassNotFoundException("Forbidden to load ObjectStreamClass for: " + osc.getName());
+            }
             return ClassUtils.forName(osc.getName());
         } catch (UnknownClassException e) {
             throw new ClassNotFoundException("Unable to load ObjectStreamClass [" + osc + "]: ", e);


### PR DESCRIPTION
A mitigation for https://github.com/apache/shiro/security/code-scanning/2
It restricts the classes that can be deserialized in ClassResolvingObjectInputStream to org.apache.shiro.* and java.util.*. 