### PR TITLE
Properly handle fluent setters

### DIFF
--- a/config/ogdl/src/main/java/org/apache/shiro/config/ogdl/ReflectionBuilder.java
+++ b/config/ogdl/src/main/java/org/apache/shiro/config/ogdl/ReflectionBuilder.java
@@ -29,8 +29,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+
 import org.apache.commons.beanutils.BeanUtilsBean;
 import org.apache.commons.beanutils.ConvertUtilsBean;
+import org.apache.commons.beanutils.FluentPropertyBeanIntrospector;
 import org.apache.commons.beanutils.SuppressPropertiesBeanIntrospector;
 import org.apache.shiro.lang.codec.Base64;
 import org.apache.shiro.lang.codec.Hex;
@@ -139,6 +141,7 @@ public class ReflectionBuilder {
             }
         });
         beanUtilsBean.getPropertyUtils().addBeanIntrospector(SuppressPropertiesBeanIntrospector.SUPPRESS_CLASS);
+        beanUtilsBean.getPropertyUtils().addBeanIntrospector(new FluentPropertyBeanIntrospector());
 
         this.interpolator = createInterpolator();
 


### PR DESCRIPTION
Currently, if I have a bean with a fluent setter (meaning it does not return `void` but `this`), it is ignored in my `shiro.ini` file.

This PR fixes the problem.

I found out the issue when upgrading buji-pac4j to pac4j v6. Here is the local patch: https://github.com/bujiio/buji-pac4j/commit/6fb21b1a7b051609f78c377d7bd3eae168875c7f#diff-ab7750a1c3bbcd663e2b0750f1ac11eac16b93c7ef5da9b8eb43af3d90ef7868R95