### PR TITLE
#1048: Solved base64 problem with remember me cookie.

### DIFF
--- a/web/src/main/java/org/apache/shiro/web/mgt/CookieRememberMeManager.java
+++ b/web/src/main/java/org/apache/shiro/web/mgt/CookieRememberMeManager.java
@@ -251,11 +251,11 @@ public class CookieRememberMeManager extends AbstractRememberMeManager {
      * @param base64 the base64 encoded String that may need to be padded
      * @return the base64 String padded if necessary.
      */
-    private String ensurePadding(String base64) {
+    protected String ensurePadding(String base64) {
         int length = base64.length();
         if (length % 4 != 0) {
             StringBuilder sb = new StringBuilder(base64);
-            for (int i = 0; i < length % 4; ++i) {
+            while (sb.length() % 4 != 0) {
                 sb.append('=');
             }
             base64 = sb.toString();


### PR DESCRIPTION
Issue 1048

The cookie value sometimes got too much '=' characters at the end.
I created a test to make the method fail, then I solved the problem. That fixed the test and made the RememberMe work again.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

