### PR TITLE
Skipping tests while running release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -677,7 +677,7 @@
                     <!-- This configuration copied from apache:apache:7 parent pom -->
                     <useReleaseProfile>false</useReleaseProfile>
                     <goals>deploy site site:stage</goals>
-                    <arguments>-Pdocs,apache-release</arguments>
+                    <arguments>-Pdocs,apache-release -DskipITs -DskipTests</arguments>
                     <mavenExecutorId>forked-path</mavenExecutorId>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Running the UTs and ITs durring the release process fails due to what looks like a classloader issue
This can be reproduce outside of the release process by running a build by running something like an "mvn verify site site:stage"
Could be a different classloader, ordering, or modulepath issue?

NOTE: I'm not a fan disabling tests durring the release, but I've spent too much time troubleshooting this issue.
