### PR TITLE
[#SHIRO-875] Fix creating subjects with disabled session-creation

### DIFF
--- a/core/src/main/java/org/apache/shiro/mgt/DefaultSecurityManager.java
+++ b/core/src/main/java/org/apache/shiro/mgt/DefaultSecurityManager.java
@@ -355,7 +355,9 @@ public class DefaultSecurityManager extends SessionsSecurityManager {
         //(this is needed here in case rememberMe principals were resolved and they need to be stored in the
         //session, so we don't constantly rehydrate the rememberMe PrincipalCollection on every operation).
         //Added in 1.2:
-        save(subject);
+        if (subjectContext.isSessionCreationEnabled()) {
+            save(subject);
+        }
 
         return subject;
     }

--- a/core/src/test/java/org/apache/shiro/mgt/DefaultSecurityManagerTest.java
+++ b/core/src/test/java/org/apache/shiro/mgt/DefaultSecurityManagerTest.java
@@ -27,6 +27,7 @@ import org.apache.shiro.realm.text.IniRealm;
 import org.apache.shiro.session.ExpiredSessionException;
 import org.apache.shiro.session.Session;
 import org.apache.shiro.session.mgt.AbstractValidatingSessionManager;
+import org.apache.shiro.subject.SimplePrincipalCollection;
 import org.apache.shiro.subject.Subject;
 import org.apache.shiro.subject.support.DelegatingSubject;
 import org.apache.shiro.util.ThreadContext;
@@ -186,5 +187,13 @@ public class DefaultSecurityManagerTest extends AbstractSecurityManagerTest {
         AuthenticationToken token = new UsernamePasswordToken("guest", "guest");
         subject.login(token);
         assertEquals(sm, subject.getSecurityManager());
+    }
+
+    @Test
+    void testNewSubjectWithoutSessionCreationEnabled() {
+        SimplePrincipalCollection principals = new SimplePrincipalCollection("guest", "asd");
+        Subject subject = new Subject.Builder().principals(principals).sessionCreationEnabled(false).buildSubject();
+
+        assertEquals(subject.getPrincipal(), "guest");
     }
 }


### PR DESCRIPTION
I didn't create a GitHub issue but there is [one in Jira](https://issues.apache.org/jira/browse/SHIRO-875). This PR fixes it.