### PR TITLE
[#SHIRO-875] Fix creating subjects from a `SubjectFactory` that disables session-creation

### DIFF
--- a/core/src/main/java/org/apache/shiro/mgt/DefaultSecurityManager.java
+++ b/core/src/main/java/org/apache/shiro/mgt/DefaultSecurityManager.java
@@ -355,7 +355,7 @@ public class DefaultSecurityManager extends SessionsSecurityManager {
         //(this is needed here in case rememberMe principals were resolved and they need to be stored in the
         //session, so we don't constantly rehydrate the rememberMe PrincipalCollection on every operation).
         //Added in 1.2:
-        if (subjectContext.isSessionCreationEnabled()) {
+        if (context.isSessionCreationEnabled()) {
             save(subject);
         }
 


### PR DESCRIPTION
I'm not sure if I had to remove the PR template after I've read it and made sure I followed everything in it. Perhaps you might want to note that in it.

This continues the work done in #1407. I didn't think of that case in it so this PR fixes it. I didn't open a new issue for it, sorry, I guess we could reuse the old one as it's a similar case.

cc @lprimak 