### PR TITLE
[#2069][BUGFIX][DOC] Prevent NPE on null principal in  DefaultLdapRealm#getLdapPrincipal

### DIFF
--- a/core/src/main/java/org/apache/shiro/realm/ldap/DefaultLdapRealm.java
+++ b/core/src/main/java/org/apache/shiro/realm/ldap/DefaultLdapRealm.java
@@ -329,13 +329,19 @@ public class DefaultLdapRealm extends AuthorizingRealm {
      * <p/>
      * If the token's {@code principal} is not a String, it is assumed to already be in the format supported by the
      * underlying {@link LdapContextFactory} implementation and the raw principal is returned directly.
+     * <p/>
+     * If the token's {@code principal} is {@code null}, an {@link AuthenticationException} will be thrown.
      *
      * @param token the {@link AuthenticationToken} submitted during the authentication process
      * @return the User DN or raw principal to use to acquire the LdapContext.
+     * @throws AuthenticationException if the principal is null
      * @see LdapContextFactory#getLdapContext(Object, Object)
      */
     protected Object getLdapPrincipal(AuthenticationToken token) {
         Object principal = token.getPrincipal();
+        if (principal == null) {
+            throw new AuthenticationException("No principal found for provided credentials");
+        }
         if (principal instanceof String) {
             String sPrincipal = (String) principal;
             return getUserDn(sPrincipal);
@@ -356,6 +362,7 @@ public class DefaultLdapRealm extends AuthorizingRealm {
      * @param token              the submitted authentication token that triggered the authentication attempt.
      * @param ldapContextFactory factory used to retrieve LDAP connections.
      * @return an {@link AuthenticationInfo} instance representing the authenticated user's information.
+     * @throws AuthenticationException if no principal is found or LDAP authentication fails.
      * @throws NamingException if any LDAP errors occur.
      */
     protected AuthenticationInfo queryForAuthenticationInfo(AuthenticationToken token,

--- a/core/src/test/java/org/apache/shiro/realm/ldap/DefaultLdapRealmTest.java
+++ b/core/src/test/java/org/apache/shiro/realm/ldap/DefaultLdapRealmTest.java
@@ -196,4 +196,23 @@ public class DefaultLdapRealmTest {
         String userDn = realm.getUserDn(principal);
         assertEquals(principal, userDn);
     }
+
+    @Test
+    void testGetLdapPrincipalNullPrincipal() {
+        AuthenticationToken token = new AuthenticationToken() {
+            @Override
+            public Object getPrincipal() {
+                return null;
+            }
+
+            @Override
+            public Object getCredentials() {
+                return "secret";
+            }
+        };
+
+        assertThrows(AuthenticationException.class, () -> {
+            realm.getLdapPrincipal(token);
+        });
+    }
 }


### PR DESCRIPTION
### What does this PR do?

This PR fixes a potential NullPointerException (NPE) in `DefaultLdapRealm#getLdapPrincipal` when the `AuthenticationToken`'s principal is `null`.  
Additionally, it updates the JavaDoc to clarify the behavior and adds a new unit test to verify the change.

---

### Changes

1. **Bug Fix in DefaultLdapRealm#getLdapPrincipal()**
   - Before: If `token.getPrincipal()` was `null`, a `NullPointerException` could occur.
   - After: Explicitly throw `AuthenticationException` when principal is `null`.
   - **Code snippet:**
     ```java
     protected Object getLdapPrincipal(AuthenticationToken token) {
         Object principal = token.getPrincipal();
         if (principal == null) {
             throw new AuthenticationException("No principal found for provided credentials");
         }
         if (principal instanceof String) {
             String sPrincipal = (String) principal;
             return getUserDn(sPrincipal);
         }
         return principal;
     }
     ```

2. **JavaDoc Update for getLdapPrincipal()**
   - Updated JavaDoc in two methods:
     - `queryForAuthenticationInfo()`
       ```java
       // Before
       @throws NamingException if any LDAP errors occur.
       
       // After
       @throws AuthenticationException if no principal is found or LDAP authentication fails.
       @throws NamingException if any LDAP errors occur.
       ```
     - `getLdapPrincipal()`
       ```java
       // Added
       @throws AuthenticationException if the principal is null

       // Also added in description:
       If the token's {@code principal} is {@code null}, an {@link AuthenticationException} will be thrown.
       ```

3. **DefaultLdapRealmTest.java**
   - Added a new unit test to verify that `AuthenticationException` is thrown when principal is `null`.
   - **Test snippet:**
     ```java
     @Test
     void testGetLdapPrincipalNullPrincipal() {
         AuthenticationToken token = new AuthenticationToken() {
             @Override
             public Object getPrincipal() {
                 return null;
             }

             @Override
             public Object getCredentials() {
                 return "secret";
             }
         };

         assertThrows(AuthenticationException.class, () -> {
             realm.getLdapPrincipal(token);
         });
     }
     ```

---

### Additional Notes

- This PR was tested locally with `mvn verify` to ensure no regressions.

---

### Related Issue

fixes #2069

---

### License

✅ I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).