### PR TITLE
OSGi fix: Set thread context classloader so deserializer in shiro-lang can find classes in shiro-core to fix #2083

### DIFF
--- a/core/src/main/java/org/apache/shiro/mgt/AbstractRememberMeManager.java
+++ b/core/src/main/java/org/apache/shiro/mgt/AbstractRememberMeManager.java
@@ -520,6 +520,8 @@ public abstract class AbstractRememberMeManager implements RememberMeManager {
      * @return the deserialized (reconstituted) {@code PrincipalCollection}
      */
     protected PrincipalCollection deserialize(byte[] serializedIdentity) {
+        // OSGi fix: shiro-core classloader needed by deserializer in shiro-lang to find classes in shiro-core
+        Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
         return getSerializer().deserialize(serializedIdentity);
     }
 


### PR DESCRIPTION
Fixes https://github.com/apache/shiro/issues/2083

The fix is that code in shiro-core (which has a classloader that "sees" all of the classes in shiro-core and shiro-lang) sets its classloader as the thread context classloader, so that the deserializer in shiro-lang (which on its own in OSGi has a classloader that does not see the classes in shiro-core) , can use the thread context classloader to find the deserialized classes.

The fix is one line, as well as one line of comment explaining why the line is there (I have filled in the contributing thing earlier, even though probably not needed for this).