### PR TITLE
[#2308] Active Directory: added Initialization test

### DIFF
--- a/core/src/test/java/org/apache/shiro/realm/activedirectory/ActiveDirectoryRealmTest.java
+++ b/core/src/test/java/org/apache/shiro/realm/activedirectory/ActiveDirectoryRealmTest.java
@@ -19,7 +19,7 @@
 package org.apache.shiro.realm.activedirectory;
 
 import org.apache.shiro.SecurityUtils;
-
+import org.apache.shiro.UnavailableSecurityManagerException;
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
@@ -28,6 +28,9 @@ import org.apache.shiro.authc.UsernamePasswordToken;
 import org.apache.shiro.authc.credential.CredentialsMatcher;
 import org.apache.shiro.authz.AuthorizationInfo;
 import org.apache.shiro.authz.SimpleAuthorizationInfo;
+import org.apache.shiro.ini.IniSecurityManagerFactory;
+import org.apache.shiro.lang.util.Factory;
+import org.apache.shiro.lang.util.LifecycleUtils;
 import org.apache.shiro.mgt.DefaultSecurityManager;
 import org.apache.shiro.mgt.SecurityManager;
 import org.apache.shiro.realm.AuthorizingRealm;
@@ -131,6 +134,21 @@ public class ActiveDirectoryRealmTest {
         // suffix matches user entry
         assertExistingUserSuffix(USERNAME + "@example.com", "testuser@example.com");
         assertExistingUserSuffix(USERNAME + "@EXAMPLE.com", "testuser@EXAMPLE.com");
+    }
+
+    @Test
+    void testInitialization() {
+        try {
+            // Initialize AD Realm
+            Factory<SecurityManager> factory = new IniSecurityManagerFactory(
+                    "classpath:org/apache/shiro/realm/activedirectory/AdRealm.withPrincipalSuffix.ini");
+            SecurityUtils.setSecurityManager(factory.getInstance());
+            // Destroy Realm
+            SecurityManager securityManager = SecurityUtils.getSecurityManager();
+            LifecycleUtils.destroy(securityManager);
+        } catch (UnavailableSecurityManagerException e) {
+        }
+        SecurityUtils.setSecurityManager(null);
     }
 
     public void assertExistingUserSuffix(String username, String expectedPrincipalName) throws Exception {

--- a/core/src/test/resources/org/apache/shiro/realm/activedirectory/AdRealm.withPrincipalSuffix.ini
+++ b/core/src/test/resources/org/apache/shiro/realm/activedirectory/AdRealm.withPrincipalSuffix.ini
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+[main]
+
+ldapRealm = org.apache.shiro.realm.activedirectory.ActiveDirectoryRealm
+
+ldapRealm.url = ldap://dc.example.com:389
+ldapRealm.systemUsername = systemuser
+ldapRealm.systemPassword = systempwd
+
+ldapRealm.searchBase = "OU=Users,DC=example,DC=com"
+ldapRealm.principalSuffix = @example.com
+ldapRealm.searchFilter = (&(objectClass=*)(mail={0}))


### PR DESCRIPTION

Adds test for issue https://github.com/apache/shiro/issues/2308 (new PR), since the original PR (https://github.com/apache/shiro/pull/2310) is already merged

@fpapon, this is the (rebased) commit I've linked here: https://github.com/apache/shiro/pull/2310#issuecomment-3438728877

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
