### PR TITLE
Actions labeler: add label for groovy files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,6 +22,12 @@ github_actions:
           - any-glob-to-any-file:
               - .github/**/*
 
+groovy:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              - '**/*.groovy'
+
 java:
   - any:
       - changed-files:


### PR DESCRIPTION
Since we have a large percentage of groovy files it makes sense to have a separate label.

There are many reasons for adding a new label and they assist with filtering, categorizing and searching.

We need to manually add a new label for "groovy" on the labels page for this code to work:

https://github.com/apache/shiro/labels
