### PR TITLE
Enable markdownlint rule MD040

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -27,8 +27,5 @@ MD033: false
 # MD034/no-bare-urls Bare URL used
 MD034: false
 
-# MD040/fenced-code-language Fenced code blocks should have a language specified
-MD040: false
-
 # MD041/first-line-heading/first-line-h1 First line in a file should be a top-level heading
 MD041: false

--- a/samples/guice/README.md
+++ b/samples/guice/README.md
@@ -6,7 +6,7 @@ A Guice example web application that show how to configure Shiro via Guice, and 
 Run the Example
 ---------------
 
-```
+```bash
 mvn jetty:run
 ```
 

--- a/samples/spring-boot-3-web/README.md
+++ b/samples/spring-boot-3-web/README.md
@@ -7,7 +7,7 @@ protected methods.
 Run the Example
 ---------------
 
-```
+```bash
 mvn spring-boot:run
 ```
 

--- a/samples/spring-boot-web/README.md
+++ b/samples/spring-boot-web/README.md
@@ -6,7 +6,7 @@ A Spring Boot example web application that show the usage of a user login, check
 Run the Example
 ---------------
 
-```
+```bash
 mvn spring-boot:run
 ```
 

--- a/samples/spring-boot/README.md
+++ b/samples/spring-boot/README.md
@@ -6,6 +6,6 @@ A Spring Boot example CLI application that show the usage of a user login, check
 Run the Example
 ---------------
 
-```
+```bash
 mvn spring-boot:run
 ```

--- a/samples/spring-hibernate/README.md
+++ b/samples/spring-hibernate/README.md
@@ -6,7 +6,7 @@ A Spring Boot example web application that show the usage of a user login with S
 Run the Example
 ---------------
 
-```
+```bash
 mvn jetty:run
 ```
 

--- a/samples/spring-mvc/README.md
+++ b/samples/spring-mvc/README.md
@@ -6,7 +6,7 @@ This example creates a web application (WAR packaged) to demonstrate configuring
 Run the Example
 ---------------
 
-```
+```bash
 mvn jetty:run-war
 ```
 

--- a/samples/spring/README.md
+++ b/samples/spring/README.md
@@ -6,7 +6,7 @@ This example creates a web application (WAR packaged) to demonstrate configuring
 Run the Example
 ---------------
 
-```
+```bash
 mvn jetty:run
 ```
 

--- a/samples/web/README.md
+++ b/samples/web/README.md
@@ -6,7 +6,7 @@ An example web application that show how to configure Shiro via a `web.xml` and 
 Run the Example
 ---------------
 
-```
+```bash
 mvn jetty:run
 ```
 


### PR DESCRIPTION
Fenced code blocks should have a language specified

Syntax highlighting designations other than bash include shell, sh, or console.

refs #2506 