### PR TITLE
chore: regenerate ignored words list `codespell.txt`

### DIFF
--- a/.github/linters/codespell.txt
+++ b/.github/linters/codespell.txt
@@ -5,7 +5,6 @@ atleast
 bais
 bu
 crypted
-isnt
 ois
 parm
 pre-pending


### PR DESCRIPTION
From the command line if you have the codespell Python package installed you can run this one line shell script to regenerate `codespell.txt`

`shiro$ codespell . | cut -f2 -d' ' | tr A-Z a-z | sort | uniq > .github/linters/codespell.txt`

After running this one word has been removed.

Tested locally after with:

`pre-commit run --all-files`

One less ignored word means increased spell check coverage
