### PR TITLE
Enable markdown-lint rule MD034

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -24,8 +24,5 @@ MD014: false
 # MD033/no-inline-html Inline HTML
 MD033: false
 
-# MD034/no-bare-urls Bare URL used
-MD034: false
-
 # MD041/first-line-heading/first-line-h1 First line in a file should be a top-level heading
 MD041: false

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Apache Shiro
 Documentation and Examples
 --------------------------
 
-https://shiro.apache.org
+<https://shiro.apache.org>
 
 Tutorials
 ---------


### PR DESCRIPTION
MD034/no-bare-urls Bare URL used

https://github.com/DavidAnson/markdownlint/blob/main/doc/md034.md
