### PR TITLE
markdown-lint: set line length to 180

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -16,7 +16,8 @@
 # under the License.
 
 # MD013/line-length Line length
-MD013: false
+MD013:
+  line_length: 180
 
 # MD014/commands-show-output Dollar signs used before commands without showing output
 MD014: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,9 @@ Contributing to Apache Shiro
 Summary
 -------
 
-This document covers how to contribute to the Apache Shiro project. These instructions assume you have a GitHub.com account, so if you don't have one you will have to create one. Your proposed code changes will be published to your own fork of the Apache Shiro project and you will submit a Pull Request for your changes to be added.
+This document covers how to contribute to the Apache Shiro project.
+These instructions assume you have a GitHub.com account, so if you don't have one you will have to create one.
+Your proposed code changes will be published to your own fork of the Apache Shiro project and you will submit a Pull Request for your changes to be added.
 
 _Let's get started!!!_
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 Apache Shiro
 ============
 
-[Apache Shiro](https://shiro.apache.org) is a powerful and easy-to-use Java security framework that performs authentication, authorization, cryptography, and session management. With Shiro’s easy-to-understand API, you can quickly and easily secure any application – from the smallest mobile applications to the largest web and enterprise applications.
+[Apache Shiro](https://shiro.apache.org) is a powerful and easy-to-use Java security framework that performs authentication, authorization, cryptography, and session management.
+With Shiro’s easy-to-understand API, you can quickly and easily secure any application – from the smallest mobile applications to the largest web and enterprise applications.
 
 Documentation and Examples
 --------------------------

--- a/samples/spring-mvc/README.md
+++ b/samples/spring-mvc/README.md
@@ -1,7 +1,8 @@
 Apache Shiro + Spring Web Example
 =================================
 
-This example creates a web application (WAR packaged) to demonstrate configuring Apache Shiro via Spring.  This example also includes a Spring Remoting example.
+This example creates a web application (WAR packaged) to demonstrate configuring Apache Shiro via Spring.
+This example also includes a Spring Remoting example.
 
 Run the Example
 ---------------

--- a/samples/spring/README.md
+++ b/samples/spring/README.md
@@ -1,7 +1,8 @@
 Apache Shiro + Spring Web Example
 =================================
 
-This example creates a web application (WAR packaged) to demonstrate configuring Apache Shiro via Spring.  This example also includes a Spring Remoting example.
+This example creates a web application (WAR packaged) to demonstrate configuring Apache Shiro via Spring.
+This example also includes a Spring Remoting example.
 
 Run the Example
 ---------------


### PR DESCRIPTION
https://github.com/DavidAnson/markdownlint/blob/main/doc/md013.md

Cleaned up some Markdown files putting each sentence on its own line results in no changes in output

When you run this check it does suggest setting the line length to 80. Not sure how many use a terminal to code etc.

We could do more cleanups and reduce the line length even further.

Long lines are hard to read in my editor and having this check will stop future regressions of very long lines in markdown files
