### PR TITLE
yamllint enable rule checking for comments

### DIFF
--- a/.github/linters/.yaml-lint.yml
+++ b/.github/linters/.yaml-lint.yml
@@ -22,7 +22,10 @@ extends: default
 rules:
   braces: disable
   brackets: disable
-  comments: disable
+  comments:
+    ignore-shebangs: true
+    min-spaces-from-content: 1
+    require-starting-space: true
   document-start: disable
   line-length: disable
   truthy: false


### PR DESCRIPTION
No changes to our existing code with these 3 rules set.

https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.comments
