### PR TITLE
gha: pr labeler label more file types

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -34,9 +34,28 @@ java:
           - any-glob-to-any-file:
               - '**/*.java'
 
+documentation:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              - '**/*.md'
+
 tests:
   - any:
       - changed-files:
           - any-glob-to-any-file:
               - '**/src/test/groovy/**/*'
               - '**/src/test/java/**/*'
+
+xml:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              - '**/*.xml'
+
+yaml:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              - '**/*.yaml'
+              - '**/*.yml'


### PR DESCRIPTION
Reasonable numbers of files to warrant labels for each type.

Counts of file types with new labels shown below:

- `find . -type f -name "*.xml" | wc -l` = 128
- `find . -type f -name "*.md" | wc -l` = 11
- `find . -type f -name "*.yml" | wc -l` = 17
- `find . -type f -name "*.yaml" | wc -l` = 2

To complete this PR we need to add the new labels on the repo label page:

https://github.com/apache/shiro/labels

3 labels to be added for: "documentation", "xml", "yaml"
