### PR TITLE
chore: remove unneeded duplicate words in java docs

### DIFF
--- a/core/src/main/java/org/apache/shiro/SecurityUtils.java
+++ b/core/src/main/java/org/apache/shiro/SecurityUtils.java
@@ -50,7 +50,7 @@ public abstract class SecurityUtils {
      * @return the currently accessible {@code Subject} accessible to the calling code.
      * @throws IllegalStateException if no {@link Subject Subject} instance or
      *                               {@link SecurityManager SecurityManager} instance is available with which to obtain
-     *                               a {@code Subject}, which which is considered an invalid application configuration
+     *                               a {@code Subject}, which is considered an invalid application configuration
      *                               - a Subject should <em>always</em> be available to the caller.
      */
     public static Subject getSubject() {

--- a/core/src/main/java/org/apache/shiro/authc/package-info.java
+++ b/core/src/main/java/org/apache/shiro/authc/package-info.java
@@ -23,7 +23,7 @@
  * 'AuthoriZation', abbreviated as <tt>authz</tt>.
  * <p/>
  * The primary item of interest in this package is the <tt>Authenticator</tt> interface, which acts as the
- * entry point (facade) to all other other authentication components. Other components, interfaces and
+ * entry point (facade) to all other authentication components. Other components, interfaces and
  * exceptions are here to support <tt>Authenticator</tt> implementations.
  */
 package org.apache.shiro.authc;

--- a/core/src/main/java/org/apache/shiro/authz/annotation/RequiresRoles.java
+++ b/core/src/main/java/org/apache/shiro/authz/annotation/RequiresRoles.java
@@ -46,7 +46,7 @@ import java.lang.annotation.Target;
  * {@link RequiresPermissions RequiresPermissions} annotation makes sense - Permission
  * types will not change during runtime for an application since permissions directly correspond to how
  * the application's functionality is programmed (that is, they reflect the application's functionality only, not
- * <em>who</em> is executing the the functionality).
+ * <em>who</em> is executing the functionality).
  *
  * @see org.apache.shiro.subject.Subject#hasRole(String)
  * @since 0.1

--- a/core/src/main/java/org/apache/shiro/mgt/SessionsSecurityManager.java
+++ b/core/src/main/java/org/apache/shiro/mgt/SessionsSecurityManager.java
@@ -73,7 +73,7 @@ public abstract class SessionsSecurityManager extends AuthorizingSecurityManager
      * <tt>SessionManager</tt> instance.
      * <p/>
      * If a <tt>SessionManager</tt> instance is not set, a default one will be automatically created and
-     * initialized appropriately for the the existing runtime environment.
+     * initialized appropriately for the existing runtime environment.
      *
      * @param sessionManager delegate instance to use to support this manager's <tt>SessionManager</tt> method calls.
      */


### PR DESCRIPTION
Minor docs clean up
