### PR TITLE
Add EditorConfig checker with pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -132,3 +132,10 @@ repos:
       - id: shellcheck
         name: run shellcheck
         description: check Shell scripts with shellcheck
+  - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
+    rev: 3.6.0
+    hooks:
+      - id: editorconfig-checker
+        name: run editorconfig-checker
+        description: a tool to verify that your files are in harmony with your .editorconfig
+        alias: ec

--- a/integration-tests/jakarta-ee/src/main/webapp/WEB-INF/errorpages/invalidErrorPage.xhtml
+++ b/integration-tests/jakarta-ee/src/main/webapp/WEB-INF/errorpages/invalidErrorPage.xhtml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html>
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one

--- a/samples/spring-boot-3-web/src/main/resources/templates/account-info.html
+++ b/samples/spring-boot-3-web/src/main/resources/templates/account-info.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -16,7 +17,6 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-<!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <title>Account Info</title>

--- a/samples/spring-boot-3-web/src/main/resources/templates/fragments/head.html
+++ b/samples/spring-boot-3-web/src/main/resources/templates/fragments/head.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -16,7 +17,6 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-<!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head th:fragment="head">
     <meta charset="utf-8"/>

--- a/samples/spring-boot-3-web/src/main/resources/templates/hello.html
+++ b/samples/spring-boot-3-web/src/main/resources/templates/hello.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -16,7 +17,6 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-<!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <title>Getting Started: Serving Web Content</title>

--- a/samples/spring-boot-3-web/src/main/resources/templates/login.html
+++ b/samples/spring-boot-3-web/src/main/resources/templates/login.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -16,7 +17,6 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-<!DOCTYPE HTML>
 <html>
 <head>
     <title>Getting Started: Serving Web Content</title>

--- a/samples/spring-boot-web/src/main/resources/templates/account-info.html
+++ b/samples/spring-boot-web/src/main/resources/templates/account-info.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -16,7 +17,6 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-<!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <title>Account Info</title>

--- a/samples/spring-boot-web/src/main/resources/templates/fragments/head.html
+++ b/samples/spring-boot-web/src/main/resources/templates/fragments/head.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -16,7 +17,6 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-<!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head th:fragment="head">
     <meta charset="utf-8"/>

--- a/samples/spring-boot-web/src/main/resources/templates/hello.html
+++ b/samples/spring-boot-web/src/main/resources/templates/hello.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -16,7 +17,6 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-<!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <title>Getting Started: Serving Web Content</title>

--- a/samples/spring-boot-web/src/main/resources/templates/login.html
+++ b/samples/spring-boot-web/src/main/resources/templates/login.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -16,7 +17,6 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-<!DOCTYPE HTML>
 <html>
 <head>
     <title>Getting Started: Serving Web Content</title>

--- a/shiro.doap.rdf
+++ b/shiro.doap.rdf
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl"?>
 <rdf:RDF xml:lang="en"
-         xmlns="http://usefulinc.com/ns/doap#"
-         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-         xmlns:asfext="http://projects.apache.org/ns/asfext#"
-         xmlns:foaf="http://xmlns.com/foaf/0.1/">
+    xmlns="http://usefulinc.com/ns/doap#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:asfext="http://projects.apache.org/ns/asfext#"
+    xmlns:foaf="http://xmlns.com/foaf/0.1/">
     <!--
         Licensed to the Apache Software Foundation (ASF) under one or more
         contributor license agreements.  See the NOTICE file distributed with
@@ -13,7 +13,7 @@
         (the "License"); you may not use this file except in compliance with
         the License.  You may obtain a copy of the License at
 
-             http://www.apache.org/licenses/LICENSE-2.0
+            http://www.apache.org/licenses/LICENSE-2.0
 
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,
@@ -134,10 +134,10 @@
         </release>
 
         <repository>
-          <GitRepository>
-            <location rdf:resource="https://git.apache.org/shiro.git"/>
-            <browse rdf:resource="https://git.apache.org/shiro.git"/>
-          </GitRepository>
+            <GitRepository>
+                <location rdf:resource="https://git.apache.org/shiro.git"/>
+                <browse rdf:resource="https://git.apache.org/shiro.git"/>
+            </GitRepository>
         </repository>
         <maintainer>
             <foaf:Person>


### PR DESCRIPTION
A Python wrapper for the main checker written in Go:

https://github.com/editorconfig-checker/editorconfig-checker.python?tab=readme-ov-file#usage-with-the-pre-commit-git-hooks-framework

https://github.com/editorconfig-checker/editorconfig-checker

Clean ups in HTML, RDF and XHTML

Standardization of the position of the `html` doctype to the top for HTML and XHTML files.

Also standardized the doctypes to one format with lowercase "html" part.

The RDF file had indentation standardized to 4 characters as detailed in the Editorconfig file.

The XHTML file seemed invalid with the XML declaration so it was removed.
