### PR TITLE
security: pre-commit add zizmor static analysis for actions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -18,7 +18,7 @@
 # https://github.com/actions/labeler
 name: Pull Request Labeler
 on:
-  - pull_request_target
+  - pull_request_target # zizmor: ignore[dangerous-triggers]
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -47,6 +47,7 @@ jobs:
         run: ./mvnw apache-rat:check "-Drat.consoleOutput"
 
       - name: Build with Maven
+        # zizmor: ignore[template-injection]
         run: >-
           ./mvnw verify --show-version --errors --batch-mode --no-transfer-progress -Pdocs
           -Pskip_jakarta_ee_tests -Dgh_user=${{ github.actor }} -Dgh_token=${{ secrets.GITHUB_TOKEN }}
@@ -94,6 +95,7 @@ jobs:
 
       - name: Build with Maven (Linux)
         if: matrix.os == 'ubuntu-latest' && matrix.jdk <= 21
+        # zizmor: ignore[template-injection]
         run: >-
           ./mvnw verify --show-version --errors --batch-mode --no-transfer-progress
           -Dgh_user=${{ github.actor }} -Dgh_token=${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,6 +115,15 @@ repos:
       - id: gitleaks
         name: run gitleaks
         description: check for secrets with gitleaks
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.22.0
+    hooks:
+      - id: zizmor
+        name: run zizmor
+        description: zizmor is a static analysis tool for GitHub Actions
+        # args: [--config=.github/linters/zizmor.yml]
+        files: ^\.github/workflows/.*$
+        types: [yaml]
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.11
     hooks:


### PR DESCRIPTION
https://zizmor.sh/

On the next ASF page under heading "Dangerous workflows" they recommend using zizmor

https://cwiki.apache.org/confluence/display/BUILDS/GitHub+Actions+Security
