### PR TITLE
Add `manual` stage pre-commit hook `chmod` for markdown permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -60,3 +60,5 @@ jobs:
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Run pre-commit
         run: pre-commit run --color=always --all-files --show-diff-on-failure
+      - name: Run manual pre-commit hooks
+        run: pre-commit run --color=always --all-files --hook-stage manual --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,15 @@ repos:
           Zip files are not allowed in the repository as they are hard to
           track and have security implications. Please remove the zip file from the repository
         files: (?i)\.zip$
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.6
+    hooks:
+      - id: chmod
+        name: set file permissions
+        description: manual hook to be run by macOS or Linux users for a full repository clean up
+        args: ['644']
+        files: \.md$
+        stages: [manual]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:


### PR DESCRIPTION
https://github.com/Lucas-C/pre-commit-hooks

Runs the `chmod` command which by default is not available on Windows

Set as a manual hook to be run as a full repo clean up.

Added the manual stage to the CI so we don't lose coverage

No Markdown files had the wrong permissions so no changes there

