### PR TITLE
Add pre-commit ecosystem to Dependabot; fix markdown-link-check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -129,3 +129,13 @@ updates:
       github-dependencies:
         patterns:
           - '*'
+
+  - package-ecosystem: 'pre-commit'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 10
+    groups:
+      github-dependencies:
+        patterns:
+          - '*'

--- a/.github/linters/mlc_config.json
+++ b/.github/linters/mlc_config.json
@@ -2,6 +2,9 @@
   "ignorePatterns": [
     {
       "pattern": "^https://github.com/YOUR_ACCOUNT/shiro"
+    },
+    {
+      "pattern": "^https://ci-builds.apache.org/job/Shiro/job/Shiro-all/job/main/"
     }
   ]
 }


### PR DESCRIPTION
Ignore link for markdown-link-check

https://github.blog/changelog/2026-03-10-dependabot-now-supports-pre-commit-hooks/

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#package-ecosystem-
