### PR TITLE
Add descriptive labels to dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -114,7 +114,7 @@ updates:
       interval: 'weekly'
     open-pull-requests-limit: 10
     groups:
-      github-dependencies:
+      github-actions-dependencies:
         patterns:
           - '*'
 
@@ -126,7 +126,7 @@ updates:
       interval: 'monthly'
     open-pull-requests-limit: 10
     groups:
-      github-dependencies:
+      github-actions-dependencies:
         patterns:
           - '*'
 
@@ -136,6 +136,6 @@ updates:
       interval: 'weekly'
     open-pull-requests-limit: 10
     groups:
-      github-dependencies:
+      pre-commit-hooks:
         patterns:
           - '*'


### PR DESCRIPTION
Labels are used in the dependabot PR titles so they add more structure and clarity to the dependabot updates.

See in #2621 we just had a generic PR title but in fact that PR was updating the pre-commit hooks

