### PR TITLE
[CI] Add basic checks workflow with one job

### DIFF
--- a/.github/workflows/basic-checks.yml
+++ b/.github/workflows/basic-checks.yml
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Basic Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+
+permissions:
+  contents: read
+
+jobs:
+  test-git-clone-on-windows:
+    timeout-minutes: 5
+    name: 'Test git clone on Windows'
+    runs-on: ['windows-latest']
+    steps:
+      - name: 'Checkout ${{ github.ref }} ( ${{ github.sha }} )'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 2
+          persist-credentials: false


### PR DESCRIPTION
Apache Airflow uses this same basic check:

https://github.com/apache/airflow/blob/3c5348fd05be80738c71eb075956f87e7d5fcec3/.github/workflows/basic-tests.yml#L293

We don't have much test coverage running on Windows.

Should be quick to run on the GitHub CI

refs https://github.com/apache/sedona/pull/2753

---

From Google:

Testing git clone on Windows is essential because of how the operating system handles files differently than Linux or macOS. Since Git was originally designed for Linux, several "Windows-specific" behaviors can cause a clone to fail or corrupt the project if not properly configured. 
The primary reasons for testing on Windows include:
1. Line Ending Inconsistencies

* The Issue: Windows uses Carriage Return + Line Feed (CRLF) for new lines, while Linux and macOS use just Line Feed (LF).
* The Risk: Without testing, a clone might automatically convert all files to CRLF, which can break scripts (like .sh files) intended to run in Docker or cross-platform environments.
* The Fix: Developers often use the git config --global core.autocrlf true setting to manage these conversions automatically. 

2. Case Sensitivity Conflicts

* The Issue: The Windows file system is typically case-insensitive (e.g., README.md and readme.md are the same file), whereas Linux is case-sensitive.
* The Risk: If a repository contains two files with the same name but different casing, cloning on Windows will result in a path collision. One file will overwrite the other, or the clone will fail with an error.
* The Fix: Testing ensures that the repository structure is compatible with the core.ignorecase setting commonly used on Windows. 

3. File Path Length Limits

* The Issue: By default, Windows has a "MAX_PATH" limit of 260 characters.
* The Risk: Deeply nested projects (common in Node.js or Java) may fail to clone because the resulting file paths are too long for Windows to handle.
* The Fix: Testing identifies if you need to enable git config --system core.longpaths true to bypass these limits. [6] 

4. Permission & Tooling Differences

* Permissions: Windows does not use the same POSIX file permissions as Linux. This can lead to "executable" bits being lost or ignored after a clone.
* SSH vs. HTTPS: Windows often requires specific credential managers or configurations for SSH keys that differ from Unix-based systems.
* Network Performance: Features like "Receive Window Auto-Tuning" in Windows can sometimes cause git clone to be significantly slower or more prone to timing out than on other platforms.

---