### PR TITLE
Add AGENTS.md + SECURITY.md linking the project's security model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# Agent guidance
+
+This file is read by automated agents (security scanners, code
+analyzers, AI assistants) operating on this repository. It
+points them at the human-authored references they should
+consult before producing output.
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md), which links to
+the canonical model document at
+<https://shiro.apache.org/security-model.html>.
+
+Agents that scan this repository should consult the linked
+security model for the project's threat model, in-scope /
+out-of-scope declarations, and known non-findings before
+reporting issues.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security
+
+Apache Shiro's security model and disclosure process are
+published on the project website rather than in the repository:
+
+- **Threat model and security policy**:
+  <https://shiro.apache.org/security-model.html>
+- **Past security advisories and CVEs**:
+  <https://shiro.apache.org/security-reports.html>
+- **How to report a vulnerability**: see the Security section
+  of <https://shiro.apache.org/>.
+
+The project website is the authoritative source; this file
+exists so agents and tooling that look for `SECURITY.md` in
+the repository can mechanically follow the link to the
+canonical documents.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,12 +3,10 @@
 Apache Shiro's security model and disclosure process are
 published on the project website rather than in the repository:
 
-- **Threat model and security policy**:
+- **Threat and security model**:
   <https://shiro.apache.org/security-model.html>
-- **Past security advisories and CVEs**:
+- **Security policy, vulnerability reporting, past advisories and CVEs**:
   <https://shiro.apache.org/security-reports.html>
-- **How to report a vulnerability**: see the Security section
-  of <https://shiro.apache.org/>.
 
 The project website is the authoritative source; this file
 exists so agents and tooling that look for `SECURITY.md` in

--- a/pom.xml
+++ b/pom.xml
@@ -359,6 +359,8 @@
                             <!-- Apparently some test in samples/spring-client generates velocity log - would better to reconfigure to output to target/ -->
                             <exclude>velocity.log</exclude>
                             <exclude>CONTRIBUTING.md</exclude>
+                            <exclude>AGENTS.md</exclude>
+                            <exclude>SECURITY.md</exclude>
                             <exclude>**/README.md</exclude>
                             <exclude>**/*.json</exclude>
                             <exclude>**/spring.factories</exclude>
@@ -1595,6 +1597,8 @@
                         <!-- Apparently some test in samples/spring-client generates velocity log - would better to reconfigure to output to target/ -->
                         <exclude>velocity.log</exclude>
                         <exclude>CONTRIBUTING.md</exclude>
+                        <exclude>AGENTS.md</exclude>
+                        <exclude>SECURITY.md</exclude>
                         <exclude>**/README.md</exclude>
                         <exclude>**/*.json</exclude>
                         <exclude>**/spring.factories</exclude>


### PR DESCRIPTION
**This is a proposal for the PMC to review — please correct,
reject, or discuss as needed.** Nothing here is a requirement;
the maintainer is the decision-maker.

This PR adds two small files at the repo root — `AGENTS.md`
and `SECURITY.md` — so an automated agent can mechanically
discover the project's existing security model.

Context: the ASF Security team is preparing Shiro for an
automated agentic security scan we're piloting. The scan
refuses to run if the model isn't discoverable by the
convention `AGENTS.md → SECURITY.md → model document`.
Refusing upfront beats wasting PMC reviewer cycles on a
noise-heavy run against a model the agent never found.
Discoverability is the one hard gate; everything else is
suggestion. The Security team has reached out separately on
the PMC's private list with the program details; this PR is
the public-facing repo piece.

Apache Shiro already has a good security model at
<https://shiro.apache.org/security-model.html>. This PR just
makes that page reachable by following the conventional
in-repo chain. Both new files are pointers; nothing about the
substantive content of the model itself changes.

Adjustments welcome on wording, file placement, or section
naming — happy to revise. If the PMC prefers different
phrasing or wants to host the model in-repo instead of on the
website, close this and we'll regroup.

The Security team uses [`threat-model-producer`](https://github.com/apache/security/blob/main/.github/skills/threat-model-producer/SKILL.md)
as the rubric for what a complete model looks like. A separate
follow-up describes completeness suggestions against that
rubric (also proposals, not requirements).
