### PR TITLE
Deprecate RandomSessionIdGenerator due to insufficient entropy

### DIFF
--- a/core/src/main/java/org/apache/shiro/session/mgt/eis/RandomSessionIdGenerator.java
+++ b/core/src/main/java/org/apache/shiro/session/mgt/eis/RandomSessionIdGenerator.java
@@ -30,7 +30,11 @@ import java.util.Random;
  * implementation is a {@link java.security.SecureRandom SecureRandom} with the {@code SHA1PRNG} algorithm.
  *
  * @since 1.0
+ * @deprecated since 2.0. Use {@link JavaUuidSessionIdGenerator} instead. This class uses only 64 bits of entropy
+ *             which is below modern industry minimums (128 bits per OWASP ASVS and NIST SP 800-63B) and poses
+ *             a security risk if used in production.
  */
+@Deprecated
 public class RandomSessionIdGenerator implements SessionIdGenerator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RandomSessionIdGenerator.class);


### PR DESCRIPTION
Marks RandomSessionIdGenerator as @Deprecated with a Javadoc pointing to JavaUuidSessionIdGenerator. The class only provides 64 bits of entropy via Long.toString(SecureRandom.nextLong()), below the 128-bit minimum required by OWASP ASVS and NIST SP 800-63B for session tokens.