### PR TITLE
[#2837] Fail closed when getPathWithinApplication() cannot normalize the request path

### DIFF
--- a/web/src/main/java/org/apache/shiro/web/filter/mgt/PathMatchingFilterChainResolver.java
+++ b/web/src/main/java/org/apache/shiro/web/filter/mgt/PathMatchingFilterChainResolver.java
@@ -150,15 +150,6 @@ public class PathMatchingFilterChainResolver implements FilterChainResolver {
             }
         }
 
-        // If no chain matched and the requestURI is null/empty, fall back to the catch-all chain if one exists.
-        // This ensures global filters (e.g. InvalidRequestFilter) always run when the request path cannot be resolved.
-        if (requestURI == null || requestURI.isEmpty()) {
-            NamedFilterList catchAllChain = filterChainManager.getChain("/**");
-            if (catchAllChain != null) {
-                return filterChainManager.proxy(originalChain, "/**");
-            }
-        }
-
         return null;
     }
 

--- a/web/src/main/java/org/apache/shiro/web/filter/mgt/PathMatchingFilterChainResolver.java
+++ b/web/src/main/java/org/apache/shiro/web/filter/mgt/PathMatchingFilterChainResolver.java
@@ -152,7 +152,7 @@ public class PathMatchingFilterChainResolver implements FilterChainResolver {
 
         // If no chain matched and the requestURI is null/empty, fall back to the catch-all chain if one exists.
         // This ensures global filters (e.g. InvalidRequestFilter) always run when the request path cannot be resolved.
-        if (requestURI == null || "".equals(requestURI)) {
+        if (requestURI == null || requestURI.isEmpty()) {
             NamedFilterList catchAllChain = filterChainManager.getChain("/**");
             if (catchAllChain != null) {
                 return filterChainManager.proxy(originalChain, "/**");

--- a/web/src/main/java/org/apache/shiro/web/filter/mgt/PathMatchingFilterChainResolver.java
+++ b/web/src/main/java/org/apache/shiro/web/filter/mgt/PathMatchingFilterChainResolver.java
@@ -150,6 +150,16 @@ public class PathMatchingFilterChainResolver implements FilterChainResolver {
             }
         }
 
+        // If no chain matched, fall back to the catch-all chain if one exists.
+        // This ensures global filters (e.g. InvalidRequestFilter) always run,
+        // even if the requestURI is null or doesn't match any pattern.
+        if (requestURI == null || "".equals(requestURI)) {
+            NamedFilterList catchAllChain = filterChainManager.getChain("/**");
+            if (catchAllChain != null) {
+                return filterChainManager.proxy(originalChain, "/**");
+            }
+        }
+
         return null;
     }
 

--- a/web/src/main/java/org/apache/shiro/web/filter/mgt/PathMatchingFilterChainResolver.java
+++ b/web/src/main/java/org/apache/shiro/web/filter/mgt/PathMatchingFilterChainResolver.java
@@ -150,9 +150,8 @@ public class PathMatchingFilterChainResolver implements FilterChainResolver {
             }
         }
 
-        // If no chain matched, fall back to the catch-all chain if one exists.
-        // This ensures global filters (e.g. InvalidRequestFilter) always run,
-        // even if the requestURI is null or doesn't match any pattern.
+        // If no chain matched and the requestURI is null/empty, fall back to the catch-all chain if one exists.
+        // This ensures global filters (e.g. InvalidRequestFilter) always run when the request path cannot be resolved.
         if (requestURI == null || "".equals(requestURI)) {
             NamedFilterList catchAllChain = filterChainManager.getChain("/**");
             if (catchAllChain != null) {

--- a/web/src/main/java/org/apache/shiro/web/util/WebUtils.java
+++ b/web/src/main/java/org/apache/shiro/web/util/WebUtils.java
@@ -118,7 +118,11 @@ public final class WebUtils {
      * @return the path within the web application
      */
     public static String getPathWithinApplication(HttpServletRequest request) {
-        return normalize(removeSemicolon(getServletPath(request) + getPathInfo(request)));
+        String path = normalize(removeSemicolon(getServletPath(request) + getPathInfo(request)));
+        if (path == null) {
+            path = "/";
+        }
+        return path;
     }
 
     /**

--- a/web/src/main/java/org/apache/shiro/web/util/WebUtils.java
+++ b/web/src/main/java/org/apache/shiro/web/util/WebUtils.java
@@ -116,15 +116,16 @@ public final class WebUtils {
      *
      * @param request current HTTP request
      * @return the path within the web application
-     * @throws IllegalStateException if the path cannot be normalized, e.g. when it
-     * traverses above the root ({@code "/.."}). Callers must fail closed instead of
-     * operating on a {@code null} path, which would otherwise bypass the filter chain.
+     * @throws IllegalStateException if the path cannot be normalized (e.g. it
+     * traverses above the root, {@code "/.."}) or is empty. Callers must fail closed
+     * instead of operating on a {@code null} path, which would otherwise bypass the
+     * filter chain.
      */
     public static String getPathWithinApplication(HttpServletRequest request) {
-        String servletPath = getServletPath(request);
-        String pathInfo = getPathInfo(request);
-        String path = normalize(removeSemicolon(servletPath + pathInfo));
-        if (path == null) {
+        String path = normalize(removeSemicolon(getServletPath(request) + getPathInfo(request)));
+        if (path == null || path.isEmpty()) {
+            String servletPath = getServletPath(request);
+            String pathInfo = getPathInfo(request);
             throw new IllegalStateException("Unable to normalize path: " + servletPath + pathInfo);
         }
         return path;

--- a/web/src/main/java/org/apache/shiro/web/util/WebUtils.java
+++ b/web/src/main/java/org/apache/shiro/web/util/WebUtils.java
@@ -116,11 +116,16 @@ public final class WebUtils {
      *
      * @param request current HTTP request
      * @return the path within the web application
+     * @throws IllegalStateException if the path cannot be normalized, e.g. when it
+     * traverses above the root ({@code "/.."}). Callers must fail closed instead of
+     * operating on a {@code null} path, which would otherwise bypass the filter chain.
      */
     public static String getPathWithinApplication(HttpServletRequest request) {
-        String path = normalize(removeSemicolon(getServletPath(request) + getPathInfo(request)));
+        String servletPath = getServletPath(request);
+        String pathInfo = getPathInfo(request);
+        String path = normalize(removeSemicolon(servletPath + pathInfo));
         if (path == null) {
-            path = "/";
+            throw new IllegalStateException("Unable to normalize path: " + servletPath + pathInfo);
         }
         return path;
     }

--- a/web/src/test/groovy/org/apache/shiro/web/util/WebUtilsTest.groovy
+++ b/web/src/test/groovy/org/apache/shiro/web/util/WebUtilsTest.groovy
@@ -177,9 +177,9 @@ class WebUtilsTest {
         doTestGetPathWithinApplication("/foobar", "//extra", "/foobar/extra");
         doTestGetPathWithinApplication("/foobar", "//extra///", "/foobar/extra/");
         doTestGetPathWithinApplication("/foo bar", "/path info", "/foo bar/path info");
-        // path traversal above root would previously return null, now returns "/" for safety
-        doTestGetPathWithinApplication("", "/../", "/");
-        doTestGetPathWithinApplication("/", "../", "/");
+        // path traversal above root returns null from normalize(); must fail closed
+        doTestGetPathWithinApplicationExpectException("", "/../");
+        doTestGetPathWithinApplicationExpectException("/", "../");
     }
 
     @Test
@@ -260,6 +260,19 @@ class WebUtilsTest {
         }
         replay request
         assertEquals expectedValue, WebUtils.getPathWithinApplication(request)
+        verify request
+    }
+
+    void doTestGetPathWithinApplicationExpectException(String servletPath, String pathInfo) {
+        def request = createMock(HttpServletRequest)
+        expect(request.getAttribute(WebUtils.INCLUDE_SERVLET_PATH_ATTRIBUTE)).andReturn(servletPath)
+        expect(request.getAttribute(WebUtils.INCLUDE_PATH_INFO_ATTRIBUTE)).andReturn(pathInfo)
+        if (pathInfo == null) {
+            expect(request.getPathInfo()).andReturn(null)
+        }
+        replay request
+        assertThrows(IllegalStateException.class,
+                () -> WebUtils.getPathWithinApplication(request))
         verify request
     }
 

--- a/web/src/test/groovy/org/apache/shiro/web/util/WebUtilsTest.groovy
+++ b/web/src/test/groovy/org/apache/shiro/web/util/WebUtilsTest.groovy
@@ -265,10 +265,11 @@ class WebUtilsTest {
 
     void doTestGetPathWithinApplicationExpectException(String servletPath, String pathInfo) {
         def request = createMock(HttpServletRequest)
-        expect(request.getAttribute(WebUtils.INCLUDE_SERVLET_PATH_ATTRIBUTE)).andReturn(servletPath)
-        expect(request.getAttribute(WebUtils.INCLUDE_PATH_INFO_ATTRIBUTE)).andReturn(pathInfo)
+        // first read: to build and normalize the path; second read: to build the exception message
+        expect(request.getAttribute(WebUtils.INCLUDE_SERVLET_PATH_ATTRIBUTE)).andReturn(servletPath).times(2)
+        expect(request.getAttribute(WebUtils.INCLUDE_PATH_INFO_ATTRIBUTE)).andReturn(pathInfo).times(2)
         if (pathInfo == null) {
-            expect(request.getPathInfo()).andReturn(null)
+            expect(request.getPathInfo()).andReturn(null).times(2)
         }
         replay request
         assertThrows(IllegalStateException.class,

--- a/web/src/test/groovy/org/apache/shiro/web/util/WebUtilsTest.groovy
+++ b/web/src/test/groovy/org/apache/shiro/web/util/WebUtilsTest.groovy
@@ -177,6 +177,9 @@ class WebUtilsTest {
         doTestGetPathWithinApplication("/foobar", "//extra", "/foobar/extra");
         doTestGetPathWithinApplication("/foobar", "//extra///", "/foobar/extra/");
         doTestGetPathWithinApplication("/foo bar", "/path info", "/foo bar/path info");
+        // path traversal above root would previously return null, now returns "/" for safety
+        doTestGetPathWithinApplication("", "/../", "/");
+        doTestGetPathWithinApplication("/", "../", "/");
     }
 
     @Test

--- a/web/src/test/java/org/apache/shiro/web/filter/mgt/NullNormalizationBypassPocTest.java
+++ b/web/src/test/java/org/apache/shiro/web/filter/mgt/NullNormalizationBypassPocTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.shiro.web.filter.mgt;
+
+import org.apache.shiro.web.util.WebUtils;
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Reproduces the filter chain bypass caused by null path normalization and asserts
+ * the fix fails closed.
+ *
+ * <p>Before the fix, {@link WebUtils#getPathWithinApplication(jakarta.servlet.http.HttpServletRequest)}
+ * returned {@code null} when {@code normalize()} failed (e.g. path traversal above root, like
+ * {@code servletPath="/"} + {@code pathInfo="../"}). The {@code null} propagated through
+ * {@link PathMatchingFilterChainResolver#getChain}, which matched no patterns and returned
+ * {@code null}, causing {@code AbstractShiroFilter} to execute the original, unfiltered
+ * container chain.</p>
+ *
+ * <p>After the fix, normalization failure throws {@link IllegalStateException}, so the
+ * request fails closed instead of being served without any Shiro filtering.</p>
+ */
+public class NullNormalizationBypassPocTest {
+
+    @Test
+    void getPathWithinApplicationThrowsForTraversalFromRoot() {
+        HttpServletRequest request = request("/", "../");
+
+        assertThrows(IllegalStateException.class,
+                () -> WebUtils.getPathWithinApplication(request));
+    }
+
+    @Test
+    void getPathWithinApplicationThrowsForTraversalAboveRoot() {
+        HttpServletRequest request = request("/app", "/../../");
+
+        assertThrows(IllegalStateException.class,
+                () -> WebUtils.getPathWithinApplication(request));
+    }
+
+    @Test
+    void resolverFailsClosedOnTraversalRequest() {
+        PathMatchingFilterChainResolver resolver = resolverWithCatchAllChain();
+        HttpServletRequest request = request("/", "../");
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain originalChain = mock(FilterChain.class);
+
+        // Before the fix this returned null (no pattern matched), which made
+        // AbstractShiroFilter fall back to the unfiltered original chain.
+        assertThrows(IllegalStateException.class,
+                () -> resolver.getChain(request, response, originalChain));
+    }
+
+    @Test
+    void resolverStillResolvesNormalRequests() {
+        PathMatchingFilterChainResolver resolver = resolverWithCatchAllChain();
+        HttpServletRequest request = request("/", "resource/menus");
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain originalChain = mock(FilterChain.class);
+
+        assertNotNull(resolver.getChain(request, response, originalChain));
+    }
+
+    private static PathMatchingFilterChainResolver resolverWithCatchAllChain() {
+        PathMatchingFilterChainResolver resolver = new PathMatchingFilterChainResolver();
+        resolver.getFilterChainManager().createChain("/**", "anon");
+        return resolver;
+    }
+
+    private static HttpServletRequest request(String servletPath, String pathInfo) {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getServletPath()).thenReturn(servletPath);
+        when(request.getPathInfo()).thenReturn(pathInfo);
+        return request;
+    }
+}

--- a/web/src/test/java/org/apache/shiro/web/filter/mgt/PathMatchingFilterChainResolverTest.java
+++ b/web/src/test/java/org/apache/shiro/web/filter/mgt/PathMatchingFilterChainResolverTest.java
@@ -313,27 +313,4 @@ public class PathMatchingFilterChainResolverTest extends WebTest {
         assertThrows(IllegalStateException.class,
                 () -> resolver.getChain(request, response, chain));
     }
-
-    /**
-     * Defense in depth: a subclass override that returns a null request URI
-     * (instead of throwing) must not bypass Shiro either - the resolver falls
-     * back to the {@code /**} catch-all chain so global filters still run.
-     */
-    @Test
-    void testNullRequestUriFromSubclassFallsBackToCatchAll() {
-        HttpServletRequest request = mock(HttpServletRequest.class);
-        HttpServletResponse response = mock(HttpServletResponse.class);
-        FilterChain chain = mock(FilterChain.class);
-
-        PathMatchingFilterChainResolver nullPathResolver = new PathMatchingFilterChainResolver() {
-            @Override
-            protected String getPathWithinApplication(ServletRequest servletRequest) {
-                return null;
-            }
-        };
-        nullPathResolver.getFilterChainManager().createChain("/**", "anon");
-
-        FilterChain resolved = nullPathResolver.getChain(request, response, chain);
-        assertThat(resolved).isNotNull();
-    }
 }

--- a/web/src/test/java/org/apache/shiro/web/filter/mgt/PathMatchingFilterChainResolverTest.java
+++ b/web/src/test/java/org/apache/shiro/web/filter/mgt/PathMatchingFilterChainResolverTest.java
@@ -290,4 +290,29 @@ public class PathMatchingFilterChainResolverTest extends WebTest {
         assertThat(resolved).isNotNull();
         verify(request).getServletPath();
     }
+
+    /**
+     * Verifies that path traversal above root (where normalize returns null)
+     * no longer bypasses Shiro. The path is normalized to "/" and can match
+     * the /** catch-all chain if one exists.
+     */
+    @Test
+    void testPathTraversalAboveRootFallsBackToCatchAll() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+
+        // Create the /** catch-all chain (as ShiroFactoryBean would)
+        resolver.getFilterChainManager().createChain("/**", "anon");
+
+        // Path that normalizes to null (above root)
+        when(request.getServletPath()).thenReturn("/");
+        when(request.getPathInfo()).thenReturn("../");
+
+        // Previously, getPathWithinApplication would return null,
+        // no pattern would match, and the resolver would return null.
+        // Now, getPathWithinApplication returns "/" and the /** chain matches.
+        FilterChain resolved = resolver.getChain(request, response, chain);
+        assertThat(resolved).isNotNull();
+    }
 }

--- a/web/src/test/java/org/apache/shiro/web/filter/mgt/PathMatchingFilterChainResolverTest.java
+++ b/web/src/test/java/org/apache/shiro/web/filter/mgt/PathMatchingFilterChainResolverTest.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests for {@link org.apache.shiro.web.filter.mgt.PathMatchingFilterChainResolver}.
@@ -293,26 +294,46 @@ public class PathMatchingFilterChainResolverTest extends WebTest {
 
     /**
      * Verifies that path traversal above root (where normalize returns null)
-     * no longer bypasses Shiro. The path is normalized to "/" and can match
-     * the /** catch-all chain if one exists.
+     * throws IllegalStateException from getPathWithinApplication.
      */
     @Test
-    void testPathTraversalAboveRootFallsBackToCatchAll() {
+    void testPathTraversalAboveRootThrowsException() {
         HttpServletRequest request = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
         FilterChain chain = mock(FilterChain.class);
 
-        // Create the /** catch-all chain (as ShiroFactoryBean would)
-        resolver.getFilterChainManager().createChain("/**", "anon");
+        // Create at least one chain so the resolver doesn't short-circuit.
+        resolver.getFilterChainManager().createChain("/public", "anon");
 
         // Path that normalizes to null (above root)
         when(request.getServletPath()).thenReturn("/");
         when(request.getPathInfo()).thenReturn("../");
 
-        // Previously, getPathWithinApplication would return null,
-        // no pattern would match, and the resolver would return null.
-        // Now, getPathWithinApplication returns "/" and the /** chain matches.
-        FilterChain resolved = resolver.getChain(request, response, chain);
+        // getPathWithinApplication throws IllegalStateException when normalize() returns null.
+        assertThrows(IllegalStateException.class,
+                () -> resolver.getChain(request, response, chain));
+    }
+
+    /**
+     * Defense in depth: a subclass override that returns a null request URI
+     * (instead of throwing) must not bypass Shiro either - the resolver falls
+     * back to the {@code /**} catch-all chain so global filters still run.
+     */
+    @Test
+    void testNullRequestUriFromSubclassFallsBackToCatchAll() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+
+        PathMatchingFilterChainResolver nullPathResolver = new PathMatchingFilterChainResolver() {
+            @Override
+            protected String getPathWithinApplication(ServletRequest servletRequest) {
+                return null;
+            }
+        };
+        nullPathResolver.getFilterChainManager().createChain("/**", "anon");
+
+        FilterChain resolved = nullPathResolver.getChain(request, response, chain);
         assertThat(resolved).isNotNull();
     }
 }


### PR DESCRIPTION
## Problem

`WebUtils.getPathWithinApplication()` returns `null` when `normalize()` fails — e.g. for path traversal above root (`servletPath="/"` + `pathInfo="../"`). The `null` propagates through `PathMatchingFilterChainResolver.getChain()`, which matches zero patterns (including `/**`) and returns `null`, causing `AbstractShiroFilter` to fall back to the original container `FilterChain` — bypassing **all** Shiro filters, including global ones like `InvalidRequestFilter`.

Introduced in commit b90f91875 (Shiro 1.5.3, CVE-2020-11989 fix) when `normalize()` was added to `getPathWithinApplication()` without a null guard; unhandled through all subsequent versions (1.5.3 → 3.0.0).

## Fix

Fail closed: `getPathWithinApplication()` now throws `IllegalStateException` when `normalize()` returns `null` or an empty path. The exception propagates through the resolver — and through the Guice `SimpleFilterChainResolver`, which calls `WebUtils` directly — to `AbstractShiroFilter`, which fails the request closed instead of serving it through the original, unfiltered chain.

Throwing (rather than remapping the path to `/`) also avoids selecting a dedicated `/` chain when a traversal request is normalized to the application root.

## Tests

- `NullNormalizationBypassPocTest` — reproduces the bypass scenario: traversal throws in `WebUtils`, the resolver fails closed (never returns null), and normal requests still resolve
- `WebUtilsTest` — traversal-above-root paths now assert the exception
- `PathMatchingFilterChainResolverTest` — traversal request throws instead of silently matching nothing

## Checklist
<!--
For Security Vulnerabilities, please email: security@shiro.apache.org
For more details on how to report a vulnerability see: https://www.apache.org/security/
-->

Following this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [GitHub issue](https://github.com/apache/shiro/issues) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a GitHub issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[#XXX] - Fixes bug in SessionManager`,
       where you replace `#XXX` with the appropriate GitHub issue. Best practice
       is to use the GitHub issue title in the pull request title and in the first line of the commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] add `fixes #XXX` if merging the PR should close a related issue.
 - [x] Run `mvn verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] Committers: Make sure a milestone is set on the PR
 - [x] Committers: Use "Squash and Merge" to combine all commits into one when merging a PR when appropriate.

Trivial changes like typos do not require a GitHub issue (javadoc, comments...).
In this case, just format the pull request title like `[DOC] - Add javadoc in SessionManager`.

If this is your first contribution, you have to read the [Contribution Guidelines](https://github.com/apache/shiro/blob/master/CONTRIBUTING.md)

If your pull request is about ~20 lines of code you don't need to sign an [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf)
if you are unsure please ask on the developers list.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

fixes #2837

