### PR TITLE
[#2818] - Skip simulateFailedLogin for AllowAllCredentialsMatcher

### DIFF
--- a/core/src/main/java/org/apache/shiro/authc/credential/AllowAllCredentialsMatcher.java
+++ b/core/src/main/java/org/apache/shiro/authc/credential/AllowAllCredentialsMatcher.java
@@ -21,7 +21,6 @@ package org.apache.shiro.authc.credential;
 import java.util.Optional;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
-import org.apache.shiro.authc.SimpleAuthenticationInfo;
 
 /**
  * A credentials matcher that always returns {@code true} when matching credentials no matter what arguments
@@ -43,8 +42,12 @@ public class AllowAllCredentialsMatcher implements CredentialsMatcher {
         return true;
     }
 
+    /**
+     * Always-matching matchers cannot supply decoy credentials that {@link #doCredentialsMatch} will reject,
+     * so simulated failed-login timing checks are skipped for realms using this matcher.
+     */
     @Override
     public Optional<AuthenticationInfo> createSimulatedCredentials() {
-        return Optional.of(new SimpleAuthenticationInfo("user", "password", "realm"));
+        return Optional.empty();
     }
 }

--- a/core/src/main/java/org/apache/shiro/realm/AuthenticatingRealm.java
+++ b/core/src/main/java/org/apache/shiro/realm/AuthenticatingRealm.java
@@ -24,6 +24,7 @@ import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.authc.IncorrectCredentialsException;
+import org.apache.shiro.authc.SimpleAuthenticationInfo;
 import org.apache.shiro.authc.UsernamePasswordToken;
 import org.apache.shiro.authc.credential.AllowAllCredentialsMatcher;
 import org.apache.shiro.authc.credential.CredentialsMatcher;
@@ -123,6 +124,12 @@ public abstract class AuthenticatingRealm extends CachingRealm implements Initia
      * @since 1.2
      */
     private static final String DEFAULT_AUTHENTICATION_CACHE_SUFFIX = ".authenticationCache";
+
+    /**
+     * Cached when a {@link CredentialsMatcher} does not supply simulated credentials so lookups are not repeated.
+     */
+    private static final AuthenticationInfo NO_SIMULATED_CREDENTIALS =
+            new SimpleAuthenticationInfo("__noSimulatedCredentials__", new Object(), "noSimulatedCredentials");
 
     /**
      * Simulated authentication info, should only be set once to avoid wasting useless CPU cycles.
@@ -617,12 +624,18 @@ public abstract class AuthenticatingRealm extends CachingRealm implements Initia
         var info = simulatedAuthenticationInfo.get();
         if (info == null) {
             getCredentialsMatcher().createSimulatedCredentials()
-                    .ifPresentOrElse(simulatedAuthenticationInfo::set, () -> LOGGER.warn(
-                            "CredentialsMatcher [{}] did not supply simulated credentials. Please update the implementation.",
-                            getCredentialsMatcher()));
-            return simulatedAuthenticationInfo.get();
+                    .ifPresentOrElse(simulatedAuthenticationInfo::set, () -> {
+                        if (!(getCredentialsMatcher() instanceof AllowAllCredentialsMatcher)) {
+                            LOGGER.warn(
+                                    "CredentialsMatcher [{}] did not supply simulated credentials. "
+                                            + "Please update the implementation.",
+                                    getCredentialsMatcher());
+                        }
+                        simulatedAuthenticationInfo.set(NO_SIMULATED_CREDENTIALS);
+                    });
+            info = simulatedAuthenticationInfo.get();
         }
-        return info;
+        return info == NO_SIMULATED_CREDENTIALS ? null : info;
     }
 
     /**

--- a/core/src/test/java/org/apache/shiro/authc/credential/AllowAllCredentialsMatcherTest.java
+++ b/core/src/test/java/org/apache/shiro/authc/credential/AllowAllCredentialsMatcherTest.java
@@ -18,9 +18,9 @@
  */
 package org.apache.shiro.authc.credential;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 
 /**
@@ -31,6 +31,11 @@ public class AllowAllCredentialsMatcherTest {
     @Test
     void testBasic() {
         assertThat(new AllowAllCredentialsMatcher().doCredentialsMatch(null, null)).isTrue();
+    }
+
+    @Test
+    void createSimulatedCredentialsShouldBeEmpty() {
+        assertThat(new AllowAllCredentialsMatcher().createSimulatedCredentials()).isEmpty();
     }
 
 }

--- a/core/src/test/java/org/apache/shiro/realm/AuthenticatingRealmJavaTest.java
+++ b/core/src/test/java/org/apache/shiro/realm/AuthenticatingRealmJavaTest.java
@@ -25,6 +25,7 @@ import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.authc.UsernamePasswordToken;
+import org.apache.shiro.authc.credential.AllowAllCredentialsMatcher;
 import org.apache.shiro.authc.credential.CredentialsMatcher;
 import org.apache.shiro.authc.credential.DefaultPasswordService;
 import org.apache.shiro.authc.credential.PasswordMatcher;
@@ -35,6 +36,19 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class AuthenticatingRealmJavaTest {
+
+    @Test
+    @DisplayName("should not simulate failed login when AllowAllCredentialsMatcher is configured")
+    void allowAllCredentialsMatcherShouldNotSimulateFailedLoginForUnknownPrincipal() {
+        AuthenticationToken token = new UsernamePasswordToken("alice", "secret".toCharArray());
+        NullAuthenticatingRealm realm = new NullAuthenticatingRealm();
+        realm.setCredentialsMatcher(new AllowAllCredentialsMatcher());
+
+        AuthenticationInfo info = realm.getAuthenticationInfo(token);
+
+        assertThat(info).isNull();
+        assertThat(realm.authInfo).isNull();
+    }
 
     @Test
     @DisplayName("should create Argon2 hash when user does not exist")


### PR DESCRIPTION
## Summary

Fixes #2818.

`AllowAllCredentialsMatcher` always returns `true` from `doCredentialsMatch`, so it cannot provide decoy simulated credentials that fail matching. When a multi-realm setup asks such a realm about an unknown principal, `simulateFailedLogin` was treating the decoy as a misconfiguration and logging a false `IncorrectCredentialsException` error on every login.

This change:
- Returns `Optional.empty()` from `AllowAllCredentialsMatcher#createSimulatedCredentials()`
- Caches the opt-out in `AuthenticatingRealm#ensureSimulatedAuthenticationInfo` so empty simulated credentials are not re-requested on every lookup
- Skips the misconfiguration warning for `AllowAllCredentialsMatcher`, since opting out is intentional

## Test plan

- [x] `mvn -pl core -am test -Dtest=AllowAllCredentialsMatcherTest,AuthenticatingRealmJavaTest -Dsurefire.failIfNoSpecifiedTests=false` (JDK 21)
- [x] Added regression test for unknown principal + `AllowAllCredentialsMatcher`
- [x] Added test asserting `createSimulatedCredentials()` is empty

Made with LLM

## Checklist
<!--
For Security Vulnerabilities, please email: security@shiro.apache.org
For more details on how to report a vulnerability see: https://www.apache.org/security/
-->

Following this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [GitHub issue](https://github.com/apache/shiro/issues) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a GitHub issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[#XXX] - Fixes bug in SessionManager`,
       where you replace `#XXX` with the appropriate GitHub issue. Best practice
       is to use the GitHub issue title in the pull request title and in the first line of the commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] add `fixes #XXX` if merging the PR should close a related issue.
 - [x] Run `mvn verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] Committers: Make sure a milestone is set on the PR
 - [x] Committers: Use "Squash and Merge" to combine all commits into one when merging a PR when appropriate.

Trivial changes like typos do not require a GitHub issue (javadoc, comments...).
In this case, just format the pull request title like `[DOC] - Add javadoc in SessionManager`.

If this is your first contribution, you have to read the [Contribution Guidelines](https://github.com/apache/shiro/blob/master/CONTRIBUTING.md)

If your pull request is about ~20 lines of code you don't need to sign an [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf)
if you are unsure please ask on the developers list.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).