### PR TITLE
Bugfix: default case insensitive filters for programmatic and Spring / Spring Boot configurations

### DIFF
--- a/core/src/main/java/org/apache/shiro/util/AntPathMatcher.java
+++ b/core/src/main/java/org/apache/shiro/util/AntPathMatcher.java
@@ -157,8 +157,7 @@ public class AntPathMatcher implements PatternMatcher {
         if (pathIdxStart > pathIdxEnd) {
             // Path is exhausted, only match if rest of pattern is * or **'s
             if (pattIdxStart > pattIdxEnd) {
-                return (pattern.endsWith(this.pathSeparator)
-                        ? path.endsWith(this.pathSeparator) : !path.endsWith(this.pathSeparator));
+                return (pattern.endsWith(this.pathSeparator) == path.endsWith(this.pathSeparator));
             }
             if (!fullMatch) {
                 return true;
@@ -225,8 +224,8 @@ public class AntPathMatcher implements PatternMatcher {
             strLoop:
             for (int i = 0; i <= strLength - patLength; i++) {
                 for (int j = 0; j < patLength; j++) {
-                    String subPat = (String) pattDirs[pattIdxStart + j + 1];
-                    String subStr = (String) pathDirs[pathIdxStart + i + j];
+                    String subPat = pattDirs[pattIdxStart + j + 1];
+                    String subStr = pathDirs[pathIdxStart + i + j];
                     if (!matchStrings(subPat, subStr)) {
                         continue strLoop;
                     }

--- a/core/src/main/java/org/apache/shiro/util/AntPathMatcher.java
+++ b/core/src/main/java/org/apache/shiro/util/AntPathMatcher.java
@@ -69,7 +69,7 @@ public class AntPathMatcher implements PatternMatcher {
     public static final String DEFAULT_PATH_SEPARATOR = "/";
 
     private String pathSeparator = DEFAULT_PATH_SEPARATOR;
-    private boolean caseInsensitive;
+    private boolean caseInsensitive = true;
 
 
     /**

--- a/core/src/main/java/org/apache/shiro/util/RegExPatternMatcher.java
+++ b/core/src/main/java/org/apache/shiro/util/RegExPatternMatcher.java
@@ -33,7 +33,7 @@ public class RegExPatternMatcher implements PatternMatcher {
 
     private static final int CASE_INSENSITIVE = DEFAULT | Pattern.CASE_INSENSITIVE;
 
-    private boolean caseInsensitive;
+    private boolean caseInsensitive = true;
 
     /**
      * Simple implementation that merely uses the default pattern comparison logic provided by the

--- a/core/src/test/java/org/apache/shiro/util/RegExPatternMatcherTest.java
+++ b/core/src/test/java/org/apache/shiro/util/RegExPatternMatcherTest.java
@@ -65,7 +65,9 @@ public class RegExPatternMatcherTest {
     }
 
     private void assertPatternNotMatch(String pattern, String path) {
-        assertPatternNotMatch(pattern, path, new RegExPatternMatcher());
+        var matcher = new RegExPatternMatcher();
+        matcher.setCaseInsensitive(false);
+        assertPatternNotMatch(pattern, path, matcher);
     }
 
     private void assertPatternNotMatch(String pattern, String path, PatternMatcher pm) {

--- a/samples/spring-mvc/src/main/java/org/apache/shiro/samples/spring/config/ApplicationConfig.java
+++ b/samples/spring-mvc/src/main/java/org/apache/shiro/samples/spring/config/ApplicationConfig.java
@@ -142,7 +142,7 @@ public class ApplicationConfig {
         chainDefinition.addPathDefinition("/WEB-INF/resources/login.jsp", "anon");
         //allow WebStart to pull the jars for the swing app
         chainDefinition.addPathDefinition("/*.jar", "anon");
-
+        chainDefinition.addPathDefinition("/**", "anon");
 
         return chainDefinition;
     }

--- a/support/spring/src/main/java/org/apache/shiro/spring/web/config/AbstractShiroWebFilterConfiguration.java
+++ b/support/spring/src/main/java/org/apache/shiro/spring/web/config/AbstractShiroWebFilterConfiguration.java
@@ -59,7 +59,7 @@ public class AbstractShiroWebFilterConfiguration {
     @Value("#{ @environment['shiro.unauthorizedUrl'] ?: null }")
     protected String unauthorizedUrl;
 
-    @Value("#{ @environment['shiro.caseInsensitive'] ?: false }")
+    @Value("#{ @environment['shiro.caseInsensitive'] ?: true }")
     protected boolean caseInsensitive;
 
     protected List<String> globalFilters() {

--- a/web/src/main/java/org/apache/shiro/web/filter/mgt/DefaultFilterChainManager.java
+++ b/web/src/main/java/org/apache/shiro/web/filter/mgt/DefaultFilterChainManager.java
@@ -69,15 +69,15 @@ public class DefaultFilterChainManager implements FilterChainManager {
     private boolean caseInsensitive = true;
 
     public DefaultFilterChainManager() {
-        this.filters = new LinkedHashMap<String, Filter>();
-        this.filterChains = new LinkedHashMap<String, NamedFilterList>();
+        this.filters = new LinkedHashMap<>();
+        this.filterChains = new LinkedHashMap<>();
         this.globalFilterNames = new ArrayList<>();
         addDefaultFilters(false);
     }
 
     public DefaultFilterChainManager(FilterConfig filterConfig) {
-        this.filters = new LinkedHashMap<String, Filter>();
-        this.filterChains = new LinkedHashMap<String, NamedFilterList>();
+        this.filters = new LinkedHashMap<>();
+        this.filterChains = new LinkedHashMap<>();
         this.globalFilterNames = new ArrayList<>();
         setFilterConfig(filterConfig);
         addDefaultFilters(true);

--- a/web/src/main/java/org/apache/shiro/web/filter/mgt/DefaultFilterChainManager.java
+++ b/web/src/main/java/org/apache/shiro/web/filter/mgt/DefaultFilterChainManager.java
@@ -66,7 +66,7 @@ public class DefaultFilterChainManager implements FilterChainManager {
      */
     private Map<String, NamedFilterList> filterChains;
 
-    private boolean caseInsensitive;
+    private boolean caseInsensitive = true;
 
     public DefaultFilterChainManager() {
         this.filters = new LinkedHashMap<String, Filter>();


### PR DESCRIPTION
This is a bug fix. During programmatic instantiation, or with Spring / Spring Boot without shiro.ini, the default behavior remained case-sensitive matching, which is incorrect and doesn't match the documentation for Shiro 3.x

Finder Credit: **0xCc.zhang**

<!--
For Security Vulnerabilities, please email: security@shiro.apache.org
For more details on how to report a vulnerability see: https://www.apache.org/security/
-->

Following this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [GitHub issue](https://github.com/apache/shiro/issues) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a GitHub issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[#XXX] - Fixes bug in SessionManager`,
       where you replace `#XXX` with the appropriate GitHub issue. Best practice
       is to use the GitHub issue title in the pull request title and in the first line of the commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] add `fixes #XXX` if merging the PR should close a related issue.
 - [x] Run `mvn verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] Committers: Make sure a milestone is set on the PR
 - [x] Committers: Use "Squash and Merge" to combine all commits into one when merging a PR when appropriate.

Trivial changes like typos do not require a GitHub issue (javadoc, comments...).
In this case, just format the pull request title like `[DOC] - Add javadoc in SessionManager`.

If this is your first contribution, you have to read the [Contribution Guidelines](https://github.com/apache/shiro/blob/master/CONTRIBUTING.md)

If your pull request is about ~20 lines of code you don't need to sign an [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf)
if you are unsure please ask on the developers list.

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
