### PR TITLE
perf(web): reduce repeated string copying in WebUtils.normalize

### DIFF
--- a/web/src/main/java/org/apache/shiro/web/util/WebUtils.java
+++ b/web/src/main/java/org/apache/shiro/web/util/WebUtils.java
@@ -222,21 +222,13 @@ public final class WebUtils {
         }
 
         // Resolve occurrences of "//" in the normalized path
-        while (true) {
-            int index = normalized.indexOf("//");
-            if (index < 0) {
-                break;
-            }
-            normalized = normalized.substring(0, index) + normalized.substring(index + 1);
+        while (normalized.contains("//")) {
+            normalized = normalized.replace("//", "/");
         }
 
         // Resolve occurrences of "/./" in the normalized path
-        while (true) {
-            int index = normalized.indexOf("/./");
-            if (index < 0) {
-                break;
-            }
-            normalized = normalized.substring(0, index) + normalized.substring(index + 2);
+        while (normalized.contains("/./")) {
+            normalized = normalized.replace("/./", "/");
         }
 
         // Resolve occurrences of "/../" in the normalized path

--- a/web/src/test/groovy/org/apache/shiro/web/util/WebUtilsTest.groovy
+++ b/web/src/test/groovy/org/apache/shiro/web/util/WebUtilsTest.groovy
@@ -209,6 +209,8 @@ class WebUtilsTest {
         doNormalizeTest "foobar", "/foobar"
         doNormalizeTest "//foobar", "/foobar"
         doNormalizeTest "//foobar///", "/foobar/"
+        doNormalizeTest "////////", "/"
+        doNormalizeTest "/./././x", "/x"
         doNormalizeTest "/context-path/foobar", "/context-path/foobar"
         doNormalizeTest "/context-path/foobar/", "/context-path/foobar/"
         doNormalizeTest "//context-path/foobar", "/context-path/foobar"


### PR DESCRIPTION
## Summary

`WebUtils.normalize()` currently removes one occurrence of `//` or `/./` per iteration. Each iteration creates a new string and scans the path again.

This change replaces all non-overlapping occurrences in each pass and repeats only while the pattern remains. It preserves the normalization order and returned paths while reducing repeated intermediate string copying for paths with repeated separators or current-directory segments.

For example:

```text
////////  ->  ////  ->  //  ->  /
/./././x  ->  /./x  ->  /x
```

## Scope

- Keeps backslash handling, `null` handling, and `/../` behavior unchanged.
- Does not change decoding or security policy.
- Does not claim a full-method complexity change; the existing `/../` loop is outside this change.

## Tests

- Added regression coverage for `////////` -> `/` and `/./././x` -> `/x`.
- Passed: `./mvnw -pl web -am -Dtest=WebUtilsTest -Dsurefire.failIfNoSpecifiedTests=false test` (`WebUtilsTest`: 7 tests, 0 failures, 0 errors).
- `./mvnw verify` reached the Jakarta EE browser integration tests. On the local macOS environment, Arquillian Drone timed out while creating a Firefox WebDriver session. This occurs outside the changed code and files.

## Checklist

- [ ] No GitHub issue was filed for this small performance-focused change.
- [x] This PR contains one behavior-preserving change only.
- [x] Focused tests passed.
- [ ] Full `mvn verify` did not complete because of the local Firefox WebDriver environment.
- [ ] I hereby declare this contribution to be licensed under the Apache License Version 2.0.